### PR TITLE
Update dockerfile as next image

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -9,14 +9,11 @@ FROM docker.io/node:${NODE_MAJOR_VERSION}-alpine AS base
 FROM base AS deps
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
 RUN apk add --no-cache libc6-compat
-RUN npm install -g pnpm
 WORKDIR /app
 
-# Copy dependency requirements
-COPY package.json pnpm-lock.yaml* ./
-
 # Install dependencies
-RUN pnpm install --frozen-lockfile
+COPY package.json pnpm-lock.yaml* ./
+RUN corepack enable pnpm && pnpm install  --frozen-lockfile
 
 # Rebuild the source code only when needed
 FROM base AS builder
@@ -29,8 +26,8 @@ COPY . .
 ENV NEXT_TELEMETRY_DISABLED 1
 
 # Build the website as standalone output.
-RUN npm --version && pnpm --version && node --version
-RUN pnpm build
+RUN npm --version && node --version
+RUN npm run build
 
 # Production image, copy all the files and run next
 FROM base AS runner


### PR DESCRIPTION
Current build breaks as the previous step uses pnpm build whereas in the next image it uses npm run build.