### PR TITLE
feat: support PENUMBRA_INDEXER_CA_CERT env var override

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,11 @@ In order to run the dex-explorer, you'll need to [deploy a Penumbra fullnode](ht
 with [ABCI event indexing enabled](https://guide.penumbra.zone/node/pd/indexing-events). The relevant env vars
 you'll want to set are:
 
-  * `PENUMBRA_GRPC_ENDPOINT`
-  * `PENUMBRA_INDEXER_ENDPOINT`
-  * `NEXT_PUBLIC_CHAIN_ID`
-  * `NEXT_PUBLIC_CUILOA_URL`
+  * `PENUMBRA_GRPC_ENDPOINT`: the URL to a remote node's `pd` gRPC service
+  * `PENUMBRA_INDEXER_ENDPOINT`: the URL to a Postgre database containing ABCI events
+  * `PENUMBRA_INDEXER_CA_CERT`: optional; if set, the database connection will use the provided certificate authority when validating TLS
+  * `NEXT_PUBLIC_CHAIN_ID`: the chain id for the network being indexed, controls asset-registry lookups
+  * `NEXT_PUBLIC_CUILOA_URL`: the URL for a block-explorer application, for generating URLs for more block/transaction info
 
 ## Name
 

--- a/justfile
+++ b/justfile
@@ -1,0 +1,6 @@
+# A justfile for dex-explorer development.
+# Documents common tasks for local dev.
+
+# build container image
+container:
+  podman build -f Containerfile .

--- a/src/utils/indexer/connector.tsx
+++ b/src/utils/indexer/connector.tsx
@@ -8,7 +8,20 @@ export class IndexerQuerier {
   private pool: Pool;
 
   constructor(connectionString: string) {
-    this.pool = new Pool({ connectionString });
+    const dbConfig = {
+      connectionString: connectionString,
+      // If a CA certificate was specified as an env var, pass that info to the database config.
+      // Be advised that if PENUMBRA_INDEXER_CA_CERT is set, then PENUMBRA_INDEXER_ENDPOINT must
+      // *lack* an `sslmode` param! This is documented here:
+      // https://node-postgres.com/features/ssl#usage-with-connectionstring
+      ...(process.env.PENUMBRA_INDEXER_CA_CERT != null && {
+        ssl: {
+            rejectUnauthorized: true,
+            ca: process.env.PENUMBRA_INDEXER_CA_CERT,
+          },
+      }),
+    };
+    this.pool = new Pool(dbConfig);
   }
 
   /**


### PR DESCRIPTION
Adds opt-in support for declaring a CA certificate value for the database TLS connection. Some managed postgres solutions, such as DigitalOcean's, require this setting. In order to use it:

  1. set the PENUMBRA_INDEXER_CA_CERT env var with the string contents of the db's CA
  2. remove the `sslmode=require` from the connection auth string

The need for 2 is because the `connectionString` param clobbers any manual `ssl` opts in the db config, and is documented here [0].

Closes #55.

[0] https://node-postgres.com/features/ssl#usage-with-connectionstring