### PR TITLE
docs: add quickstart docs for dev env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ yarn-error.log*
 .vercel
 
 tsconfig.tsbuildinfo
+
+# ignore database CA certificate, required for some db backends
+ca-cert.pem

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1726560853,
+        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1727140925,
+        "narHash": "sha256-ZHSasdLwEEjSOD/WTW1o7dr3/EjuYsdwYB4NSgICZ2I=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "189e5f171b163feb7791a9118afa778d9a1db81f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,24 @@
+{
+  description = "Dev shell for Penumbra DEX explorer web application";
+  # inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.05";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+  inputs.flake-utils.url = "github:numtide/flake-utils";
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let pkgs = nixpkgs.legacyPackages.${system}; in
+      {
+        devShells.default = pkgs.mkShell {
+          name = "devShell";
+          nativeBuildInputs = [ pkgs.bashInteractive ];
+          buildInputs = with pkgs; [
+            fd
+            file
+            jq
+            just
+            pnpm
+            postgresql
+          ];
+        };
+      });
+}

--- a/justfile
+++ b/justfile
@@ -1,6 +1,11 @@
 # A justfile for dex-explorer development.
 # Documents common tasks for local dev.
 
+# run the app locally with live reload, via pnpm
+dev:
+  pnpm install
+  pnpm dev
+
 # build container image
 container:
   podman build -f Containerfile .


### PR DESCRIPTION
Adds a nix config so that tooling like `pnpm` is available immediately. Fleshes out the documentation around connecting to managed database instances, since merge of #56.