### PR TITLE
fix: #87: support styled-components in SSR to solve FOUC

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -2,6 +2,9 @@
 
 const nextConfig = {
   transpilePackages: ["@penumbra-zone/protobuf"],
+  compiler: {
+    styledComponents: true,
+  },
   webpack: (config) => {
     config.module.rules.push({
       test: /\.svg$/i,

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "zod": "^3.23.8"
   },
   "devDependencies": {
+    "styled-components": "^6.1.13",
     "@babel/core": "^7.25.2",
     "@babel/preset-env": "^7.25.4",
     "@babel/preset-react": "^7.24.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -219,6 +219,9 @@ importers:
       postcss:
         specifier: ^8.4.47
         version: 8.4.47
+      styled-components:
+        specifier: ^6.1.13
+        version: 6.1.13(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       tailwindcss:
         specifier: ^3.4.12
         version: 3.4.12

--- a/src/app/StyleRegistry.tsx
+++ b/src/app/StyleRegistry.tsx
@@ -1,0 +1,35 @@
+'use client'
+
+import { useState, ReactNode } from 'react';
+import { useServerInsertedHTML } from 'next/navigation';
+import { ServerStyleSheet, StyleSheetManager } from 'styled-components';
+
+/**
+ * Needed to ensure that styled-components styles are rendered on the server.
+ * https://nextjs.org/docs/app/building-your-application/styling/css-in-js#styled-components
+ */
+export const StyledComponentsRegistry = ({
+  children,
+}: {
+  children: ReactNode,
+}) => {
+  // Only create stylesheet once with lazy initial state
+  // x-ref: https://reactjs.org/docs/hooks-reference.html#lazy-initial-state
+  const [styledComponentsStyleSheet] = useState(() => new ServerStyleSheet());
+
+  useServerInsertedHTML(() => {
+    const styles = styledComponentsStyleSheet.getStyleElement();
+    styledComponentsStyleSheet.instance.clearTag();
+    return <>{styles}</>;
+  });
+
+  if (typeof window !== 'undefined') {
+    return <>{children}</>;
+  }
+
+  return (
+    <StyleSheetManager sheet={styledComponentsStyleSheet.instance}>
+      {children}
+    </StyleSheetManager>
+  );
+};

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,11 +1,14 @@
 import { ReactNode } from 'react';
 import '@/v2.css';
+import { StyledComponentsRegistry } from './StyleRegistry';
 
 const RootLayout = ({ children }: { children: ReactNode }) => {
   return (
     <html lang="en">
       <body>
-        {children}
+        <StyledComponentsRegistry>
+          {children}
+        </StyledComponentsRegistry>
       </body>
     </html>
   )


### PR DESCRIPTION
Fixes #87 

Solves the issue with FOUC in server-side environment.

Tried creating the same `StyledComponentsRegistry` component in the UI package but apparently it cannot be used in NextJS after the Vite's build. That's why the whole piece of code is put here. However, we should document this in the UI package docs for the future.