### PR TITLE
ci: add automatic deploys to testnet environment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,55 @@
+---
+# Workflow for deploying the DEX explorer webapp https://github.com/penumbra-zone/dex-explorer
+# Bounces a container deployment, to repull the latest image.
+name: deploy dex-explorer
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-container:
+    name: build container
+    uses: ./.github/workflows/container.yml
+    secrets: inherit
+    permissions:
+      contents: read
+      packages: write
+
+  deploy-testnet:
+    name: deploy dex-explorer to testnet
+    env:
+      DIGITALOCEAN_ACCESS_TOKEN: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+    needs:
+      - build-container
+    runs-on: buildjet-8vcpu-ubuntu-2204
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: install nix
+        uses: nixbuild/nix-quick-install-action@v28
+
+      - name: setup nix cache
+        uses: nix-community/cache-nix-action@v5
+        with:
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-
+          backend: buildjet
+
+      # Confirm that the nix devshell is buildable and runs at all.
+      - name: validate nix env
+        run: nix develop --command echo hello
+
+      - name: save DigitalOcean kubeconfig with short-lived credentials
+        run: >
+          nix develop --command
+          doctl kubernetes cluster kubeconfig save --expiry-seconds 600 plinfra
+
+      # We assume that dex-explorer has been deployed to the cluster already.
+      # This task merely "bounces" the service, so that a fresh container is pulled.
+      - name: deploy dex-explorer
+        run: >
+          nix develop --command
+          kubectl rollout restart deployment dex-explorer-testnet
+          kubectl rollout status deployment dex-explorer-testnet

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1727140925,
-        "narHash": "sha256-ZHSasdLwEEjSOD/WTW1o7dr3/EjuYsdwYB4NSgICZ2I=",
+        "lastModified": 1728409405,
+        "narHash": "sha256-kk530XBUGDpt0DQbyUb3yDpSddPqF9PA5KTo/nsmmg0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "189e5f171b163feb7791a9118afa778d9a1db81f",
+        "rev": "1366d1af8f58325602280e43ed6233849fb92216",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -18,6 +18,10 @@
             just
             pnpm
             postgresql
+
+            # for deployment/ci
+            doctl
+            kubectl
           ];
         };
       });


### PR DESCRIPTION
Now that we've resolved #73, we're unblocked from restoring rolling deployments on merge to main, to the testnet instance [0]. This new workflow blocks on completion of the build-container logic, then bounces the pre-existing deployment to pull the most recently built container.

Refs #72.

[0] https://dex-explorer.testnet.plinfra.net