### PR TITLE
ci: only build container once per merge

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -1,10 +1,12 @@
 ---
 name: Build container image
 on:
-  # By default, build on merge to main.
-  push:
-    branches:
-      - main
+  # Don't build on merge into main:
+  # instead, we'll trigger the container build via the "deploy" workflow,
+  # which runs on merge to main.
+  # push:
+  #   branches:
+  #     - main
 
   # Also support ad-hoc and per-repo calls to trigger builds.
   workflow_call:
@@ -22,13 +24,13 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Log in to the Docker Hub container registry (for pulls)
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Log in to the GitHub container registry (for pushes)
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -36,12 +38,12 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         with:
           images: ghcr.io/penumbra-zone/dex-explorer
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v5
         with:
           context: .
           platforms: linux/amd64

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -51,5 +51,6 @@ jobs:
       - name: deploy dex-explorer
         run: >
           nix develop --command
-          kubectl rollout restart deployment dex-explorer-testnet
+          kubectl rollout restart deployment dex-explorer-testnet &&
+          nix develop --command
           kubectl rollout status deployment dex-explorer-testnet


### PR DESCRIPTION
Since the deploy workflow depends on the container workflow, we'll trigger the latter on running the former. Therefore the container workflow shouldn't run on its on when main changes.

Also cleans up the post-deploy wait-for task to use proper shell commands.

Follow-up to https://github.com/penumbra-zone/dex-explorer/pull/90. Refs #72.