### PR TITLE
build: update container image context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,17 @@
-Containerfile
-.dockerignore
-node_modules
-npm-debug.log
-README.md
-.next
-.git
+# ignore everything by default
+**
+
+# allow JS files
+!*.ts
+!*.js
+!*.mjs
+!*.json
+!pnpm-lock.yaml
+!pnpm-workspace.yaml
+
+# allow app source code
+!.next/
+!app/
+!pages/
+!public/
+!src/

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ yarn-error.log*
 
 # Support direnv, as well
 .envrc
+.direnv
 
 # webpack
 /dist
@@ -44,3 +45,4 @@ tsconfig.tsbuildinfo
 
 # ignore database CA certificate, required for some db backends
 ca-cert.pem
+*.pem

--- a/Containerfile
+++ b/Containerfile
@@ -5,15 +5,16 @@
 # Should match what's in .nvmrc for development.
 ARG NODE_MAJOR_VERSION=18.20
 FROM docker.io/node:${NODE_MAJOR_VERSION}-alpine AS base
+RUN corepack enable pnpm
+
 # Install dependencies only when needed
 FROM base AS deps
 # Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
 RUN apk add --no-cache libc6-compat
 WORKDIR /app
-
 # Install dependencies
 COPY package.json pnpm-lock.yaml* ./
-RUN corepack enable pnpm && pnpm install  --frozen-lockfile
+RUN pnpm install  --frozen-lockfile
 
 # Rebuild the source code only when needed
 FROM base AS builder
@@ -26,8 +27,8 @@ COPY . .
 ENV NEXT_TELEMETRY_DISABLED 1
 
 # Build the website as standalone output.
-RUN npm --version && node --version
-RUN npm run build
+RUN pnpm --version && node --version
+RUN pnpm run build
 
 # Production image, copy all the files and run next
 FROM base AS runner

--- a/justfile
+++ b/justfile
@@ -8,4 +8,11 @@ dev:
 
 # build container image
 container:
-  podman build -f Containerfile .
+  podman build -t ghcr.io/penumbra-zone/dex-explorer -f Containerfile .
+
+# build, then run the container image. uses local env vars.
+run-container: container
+  podman run \
+    -e PENUMBRA_INDEXER_ENDPOINT -e PENUMBRA_INDEXER_CA_CERT -e PENUMBRA_GRPC_ENDPOINT \
+    -e PENUMBRA_CHAIN_ID -e PENUMBRA_CUILOA_URL \
+    -p 3000:3000 -it ghcr.io/penumbra-zone/dex-explorer


### PR DESCRIPTION
We noticed a regression between v1 and v2 versions in the built container. In the local dev env, created via `pnpm run dev`, v2 served just fine, but the container uses `pnpm run build` output for a prod site, and that site works differently.

Small changes throughout:

  * updated justfile targets to facilitate local testing of containers
  * refreshed dockerignore file for faster local container builds
  * migrated use of `npm` in container build to `pnpm` for consistency

These are all good changes but we still don't have a fully working v2 site served via container.