### PR TITLE
Make env route dynamic

### DIFF
--- a/app/api/env/route.ts
+++ b/app/api/env/route.ts
@@ -1,1 +1,4 @@
 export { GET } from '@/shared/api/server/env';
+
+// Prevents static generation of API route result at build time
+export const dynamic = 'force-dynamic';


### PR DESCRIPTION
Possibly closes https://github.com/penumbra-zone/dex-explorer/issues/121

By default, the `api/env` route was being built statically at build time. It looks like Nextjs recognized that it depended on static variables (env vars) and thought it a good idea to pre-build the route's response #facepalm. 

Before:
<img width="926" alt="Screenshot 2024-11-04 at 10 43 03 AM" src="https://github.com/user-attachments/assets/a3a258b5-590d-4840-8fb1-5064628b2259">


After:


<img width="927" alt="Screenshot 2024-11-04 at 10 42 08 AM" src="https://github.com/user-attachments/assets/54259f1c-7854-4463-87eb-9bdf1ca9bc62">

