### PR TITLE
ci: add another deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,3 +54,40 @@ jobs:
           kubectl -n testnet rollout restart deployment dex-explorer &&
           nix develop --command
           kubectl -n testnet rollout status deployment dex-explorer
+  deploy-mainnet:
+    name: deploy dex-explorer to mainnet
+    env:
+      DIGITALOCEAN_ACCESS_TOKEN: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+    needs:
+      - build-container
+    runs-on: buildjet-8vcpu-ubuntu-2204
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: install nix
+        uses: nixbuild/nix-quick-install-action@v28
+
+      - name: setup nix cache
+        uses: nix-community/cache-nix-action@v5
+        with:
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-
+          backend: buildjet
+
+      # Confirm that the nix devshell is buildable and runs at all.
+      - name: validate nix env
+        run: nix develop --command echo hello
+
+      - name: save DigitalOcean kubeconfig with short-lived credentials
+        run: >
+          nix develop --command
+          doctl kubernetes cluster kubeconfig save --expiry-seconds 600 plinfra
+
+      # We assume that dex-explorer has been deployed to the cluster already.
+      # This task merely "bounces" the service, so that a fresh container is pulled.
+      - name: deploy dex-explorer
+        run: >
+          nix develop --command
+          kubectl -n mainnet rollout restart deployment dex-explorer &&
+          nix develop --command
+          kubectl -n mainnet rollout status deployment dex-explorer


### PR DESCRIPTION
Deploys another instance of the dex-explorer, also on merges into main branch. This new logic is straightforward, but won't run until merge: that's fine, I'll follow-up post-merge and make sure it's working correctly.