### PR TITLE
feat: #143: experimentally request summary data on server

### DIFF
--- a/app/app.tsx
+++ b/app/app.tsx
@@ -6,7 +6,7 @@ import { QueryClientProvider } from '@tanstack/react-query';
 import { ToastProvider } from '@penumbra-zone/ui/Toast';
 import { TooltipProvider } from '@penumbra-zone/ui/Tooltip';
 import { Header, SyncBar } from '@/widgets/header';
-import { queryClient } from '@/shared/const/queryClient';
+import { getQueryClient } from '@/shared/const/queryClient';
 
 // Used so that observer() won't subscribe to any observables used in an SSR environment
 // and no garbage collection problems are introduced.
@@ -14,7 +14,7 @@ enableStaticRendering(typeof window === 'undefined');
 
 export const App = ({ children }: { children: ReactNode }) => {
   return (
-    <QueryClientProvider client={queryClient}>
+    <QueryClientProvider client={getQueryClient()}>
       <TooltipProvider>
         <main className='relative z-0'>
           <SyncBar />

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -34,9 +34,6 @@ const PnpmInstallPlugin = {
 
 const nextConfig = {
   transpilePackages: ['@penumbra-zone/protobuf'],
-  compiler: {
-    styledComponents: true,
-  },
   webpack: config => {
     config.module.rules.push({
       test: /\.svg$/i,

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "babel-loader": "^9.1.3",
     "eslint": "8.57.0",
     "eslint-config-next": "14.2.3",
-    "eslint-plugin-react": "^7.35.2",
+    "eslint-plugin-react": "^7.37.2",
     "globals": "^15.9.0",
     "kysely-codegen": "^0.17.0",
     "postcss": "^8.4.47",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -256,8 +256,8 @@ importers:
         specifier: 14.2.3
         version: 14.2.3(eslint-plugin-import-x@0.5.3(eslint@8.57.0)(typescript@5.6.2))(eslint@8.57.0)(typescript@5.6.2)
       eslint-plugin-react:
-        specifier: ^7.35.2
-        version: 7.35.2(eslint@8.57.0)
+        specifier: ^7.37.2
+        version: 7.37.2(eslint@8.57.0)
       globals:
         specifier: ^15.9.0
         version: 15.9.0
@@ -3887,6 +3887,10 @@ packages:
     resolution: {integrity: sha512-e+HfNH61Bj1X9/jLc5v1owaLYuHdeHHSQlkhCBiTK8rBvKaULl/beGMxwrMXjpYrv4pz22BlY570vVePA2ho4A==}
     engines: {node: '>= 0.4'}
 
+  es-abstract@1.23.5:
+    resolution: {integrity: sha512-vlmniQ0WNPwXqA0BnmwV3Ng7HxiGlh6r5U6JcTMNx8OilcAGqVJBHJcPjqOMaczU9fRuRK5Px2BdVyPRnKMMVQ==}
+    engines: {node: '>= 0.4'}
+
   es-define-property@1.0.0:
     resolution: {integrity: sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==}
     engines: {node: '>= 0.4'}
@@ -3900,6 +3904,10 @@ packages:
 
   es-iterator-helpers@1.0.19:
     resolution: {integrity: sha512-zoMwbCcH5hwUkKJkT8kDIBZSz9I6mVG//+lDCinLCGov4+r7NIy0ld8o03M0cJxl2spVf6ESYVS6/gpIfq1FFw==}
+    engines: {node: '>= 0.4'}
+
+  es-iterator-helpers@1.2.0:
+    resolution: {integrity: sha512-tpxqxncxnpw3c93u8n3VOzACmRFoVmWJqbWXvX/JfKbkhBw1oslgPrUfeSt2psuqyEJFD6N/9lg5i7bsKpoq+Q==}
     engines: {node: '>= 0.4'}
 
   es-module-lexer@1.5.4:
@@ -4047,8 +4055,8 @@ packages:
     peerDependencies:
       eslint: '>=7'
 
-  eslint-plugin-react@7.35.2:
-    resolution: {integrity: sha512-Rbj2R9zwP2GYNcIak4xoAMV57hrBh3hTaR0k7hVjwCQgryE/pw5px4b13EYjduOI0hfXyZhwBxaGpOTbWSGzKQ==}
+  eslint-plugin-react@7.37.2:
+    resolution: {integrity: sha512-EsTAnj9fLVr/GZleBLFbj/sSuXeWmp1eXIN60ceYnZveqEaUCyW4X+Vh4WTdUhCkW4xutXYqTXCUSyqD4rB75w==}
     engines: {node: '>=4'}
     peerDependencies:
       eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7
@@ -4590,6 +4598,10 @@ packages:
   iterator.prototype@1.1.2:
     resolution: {integrity: sha512-DR33HMMr8EzwuRL8Y9D3u2BMj8+RqSE850jfGu59kS7tbmPLzGkZmVSfyCFSDxuZiEY6Rzt3T2NA/qU+NwVj1w==}
 
+  iterator.prototype@1.1.3:
+    resolution: {integrity: sha512-FW5iMbeQ6rBGm/oKgzq2aW4KvAGpxPzYES8N4g4xNXUKpL1mclMvOe+76AcLDTvD+Ze+sOpVhgdAQEKF4L9iGQ==}
+    engines: {node: '>= 0.4'}
+
   jackspeak@2.3.6:
     resolution: {integrity: sha512-N3yCS/NegsOBokc8GAdM8UcmfsKiSS8cipheD/nivzr700H+nsMOxJjQnvwOcRYVuFkdH0wGUvW2WbXGmrZGbQ==}
     engines: {node: '>=14'}
@@ -4942,6 +4954,10 @@ packages:
 
   object-inspect@1.13.2:
     resolution: {integrity: sha512-IRZSRuzJiynemAXPYtPe5BoI/RESNYR7TYm50MC5Mqbd3Jmw5y790sErYw3V6SryFJD64b74qQQs9wn5Bg/k3g==}
+    engines: {node: '>= 0.4'}
+
+  object-inspect@1.13.3:
+    resolution: {integrity: sha512-kDCGIbxkDSXE3euJZZXzc6to7fCrKHNI/hSRQnRuQ+BWjFNzZwiFF8fj/6o2t2G9/jTj8PSIYTfCLelLZEeRpA==}
     engines: {node: '>= 0.4'}
 
   object-is@1.1.6:
@@ -5375,6 +5391,10 @@ packages:
 
   regexp.prototype.flags@1.5.2:
     resolution: {integrity: sha512-NcDiDkTLuPR+++OCKB0nWafEmhg/Da8aUPLPMQbK+bxKKCm1/S5he+AqYa4PlMCVBalb4/yxIRub6qkEx5yJbw==}
+    engines: {node: '>= 0.4'}
+
+  regexp.prototype.flags@1.5.3:
+    resolution: {integrity: sha512-vqlC04+RQoFalODCbCumG2xIOvapzVMHwsyIGM/SIE8fRhFFsXeH8/QQ+s0T0kDAhKc4k30s73/0ydkHQz6HlQ==}
     engines: {node: '>= 0.4'}
 
   regexpu-core@5.3.2:
@@ -10110,6 +10130,55 @@ snapshots:
       unbox-primitive: 1.0.2
       which-typed-array: 1.1.15
 
+  es-abstract@1.23.5:
+    dependencies:
+      array-buffer-byte-length: 1.0.1
+      arraybuffer.prototype.slice: 1.0.3
+      available-typed-arrays: 1.0.7
+      call-bind: 1.0.7
+      data-view-buffer: 1.0.1
+      data-view-byte-length: 1.0.1
+      data-view-byte-offset: 1.0.0
+      es-define-property: 1.0.0
+      es-errors: 1.3.0
+      es-object-atoms: 1.0.0
+      es-set-tostringtag: 2.0.3
+      es-to-primitive: 1.2.1
+      function.prototype.name: 1.1.6
+      get-intrinsic: 1.2.4
+      get-symbol-description: 1.0.2
+      globalthis: 1.0.4
+      gopd: 1.0.1
+      has-property-descriptors: 1.0.2
+      has-proto: 1.0.3
+      has-symbols: 1.0.3
+      hasown: 2.0.2
+      internal-slot: 1.0.7
+      is-array-buffer: 3.0.4
+      is-callable: 1.2.7
+      is-data-view: 1.0.1
+      is-negative-zero: 2.0.3
+      is-regex: 1.1.4
+      is-shared-array-buffer: 1.0.3
+      is-string: 1.0.7
+      is-typed-array: 1.1.13
+      is-weakref: 1.0.2
+      object-inspect: 1.13.3
+      object-keys: 1.1.1
+      object.assign: 4.1.5
+      regexp.prototype.flags: 1.5.3
+      safe-array-concat: 1.1.2
+      safe-regex-test: 1.0.3
+      string.prototype.trim: 1.2.9
+      string.prototype.trimend: 1.0.8
+      string.prototype.trimstart: 1.0.8
+      typed-array-buffer: 1.0.2
+      typed-array-byte-length: 1.0.1
+      typed-array-byte-offset: 1.0.2
+      typed-array-length: 1.0.6
+      unbox-primitive: 1.0.2
+      which-typed-array: 1.1.15
+
   es-define-property@1.0.0:
     dependencies:
       get-intrinsic: 1.2.4
@@ -10143,6 +10212,24 @@ snapshots:
       has-symbols: 1.0.3
       internal-slot: 1.0.7
       iterator.prototype: 1.1.2
+      safe-array-concat: 1.1.2
+
+  es-iterator-helpers@1.2.0:
+    dependencies:
+      call-bind: 1.0.7
+      define-properties: 1.2.1
+      es-abstract: 1.23.5
+      es-errors: 1.3.0
+      es-set-tostringtag: 2.0.3
+      function-bind: 1.1.2
+      get-intrinsic: 1.2.4
+      globalthis: 1.0.4
+      gopd: 1.0.1
+      has-property-descriptors: 1.0.2
+      has-proto: 1.0.3
+      has-symbols: 1.0.3
+      internal-slot: 1.0.7
+      iterator.prototype: 1.1.3
       safe-array-concat: 1.1.2
 
   es-module-lexer@1.5.4: {}
@@ -10236,7 +10323,7 @@ snapshots:
       eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import-x@0.5.3(eslint@8.57.0)(typescript@5.6.2))(eslint-plugin-import@2.30.0)(eslint@8.57.0)
       eslint-plugin-import: 2.30.0(@typescript-eslint/parser@7.2.0(eslint@8.57.0)(typescript@5.6.2))(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.0)
       eslint-plugin-jsx-a11y: 6.10.0(eslint@8.57.0)
-      eslint-plugin-react: 7.35.2(eslint@8.57.0)
+      eslint-plugin-react: 7.37.2(eslint@8.57.0)
       eslint-plugin-react-hooks: 4.6.2(eslint@8.57.0)
     optionalDependencies:
       typescript: 5.6.2
@@ -10443,14 +10530,14 @@ snapshots:
     dependencies:
       eslint: 9.10.0(jiti@1.21.6)
 
-  eslint-plugin-react@7.35.2(eslint@8.57.0):
+  eslint-plugin-react@7.37.2(eslint@8.57.0):
     dependencies:
       array-includes: 3.1.8
       array.prototype.findlast: 1.2.5
       array.prototype.flatmap: 1.3.2
       array.prototype.tosorted: 1.1.4
       doctrine: 2.1.0
-      es-iterator-helpers: 1.0.19
+      es-iterator-helpers: 1.2.0
       eslint: 8.57.0
       estraverse: 5.3.0
       hasown: 2.0.2
@@ -10465,14 +10552,14 @@ snapshots:
       string.prototype.matchall: 4.0.11
       string.prototype.repeat: 1.0.0
 
-  eslint-plugin-react@7.35.2(eslint@9.10.0(jiti@1.21.6)):
+  eslint-plugin-react@7.37.2(eslint@9.10.0(jiti@1.21.6)):
     dependencies:
       array-includes: 3.1.8
       array.prototype.findlast: 1.2.5
       array.prototype.flatmap: 1.3.2
       array.prototype.tosorted: 1.1.4
       doctrine: 2.1.0
-      es-iterator-helpers: 1.0.19
+      es-iterator-helpers: 1.2.0
       eslint: 9.10.0(jiti@1.21.6)
       estraverse: 5.3.0
       hasown: 2.0.2
@@ -11102,6 +11189,14 @@ snapshots:
       reflect.getprototypeof: 1.0.6
       set-function-name: 2.0.2
 
+  iterator.prototype@1.1.3:
+    dependencies:
+      define-properties: 1.2.1
+      get-intrinsic: 1.2.4
+      has-symbols: 1.0.3
+      reflect.getprototypeof: 1.0.6
+      set-function-name: 2.0.2
+
   jackspeak@2.3.6:
     dependencies:
       '@isaacs/cliui': 8.0.2
@@ -11386,6 +11481,8 @@ snapshots:
 
   object-inspect@1.13.2: {}
 
+  object-inspect@1.13.3: {}
+
   object-is@1.1.6:
     dependencies:
       call-bind: 1.0.7
@@ -11640,7 +11737,7 @@ snapshots:
       eslint-plugin-import: 2.30.0(@typescript-eslint/parser@7.18.0(eslint@8.57.0)(typescript@5.6.2))(eslint@8.57.0)
       eslint-plugin-import-x: 0.5.3(eslint@9.10.0(jiti@1.21.6))(typescript@5.6.2)
       eslint-plugin-prettier: 5.2.1(eslint-config-prettier@9.1.0(eslint@8.57.0))(eslint@9.10.0(jiti@1.21.6))(prettier@3.3.3)
-      eslint-plugin-react: 7.35.2(eslint@9.10.0(jiti@1.21.6))
+      eslint-plugin-react: 7.37.2(eslint@9.10.0(jiti@1.21.6))
       eslint-plugin-react-hooks: 5.1.0-rc-c3cdbec0a7-20240708(eslint@9.10.0(jiti@1.21.6))
       eslint-plugin-react-refresh: 0.4.11(eslint@9.10.0(jiti@1.21.6))
       eslint-plugin-storybook: 0.9.0--canary.156.ed236ca.0(eslint@9.10.0(jiti@1.21.6))(typescript@5.6.2)
@@ -11856,6 +11953,13 @@ snapshots:
       '@babel/runtime': 7.25.6
 
   regexp.prototype.flags@1.5.2:
+    dependencies:
+      call-bind: 1.0.7
+      define-properties: 1.2.1
+      es-errors: 1.3.0
+      set-function-name: 2.0.2
+
+  regexp.prototype.flags@1.5.3:
     dependencies:
       call-bind: 1.0.7
       define-properties: 1.2.1

--- a/src/pages/trade/model/use-path.ts
+++ b/src/pages/trade/model/use-path.ts
@@ -1,8 +1,10 @@
+'use client';
+
 import { useAssets } from '@/shared/api/assets';
 import { useParams } from 'next/navigation';
 import { useQuery } from '@tanstack/react-query';
 
-interface PathParams {
+export interface PathParams {
   baseSymbol: string;
   quoteSymbol: string;
   [key: string]: string; // required for useParams signature
@@ -10,7 +12,7 @@ interface PathParams {
 
 export const usePathSymbols = () => {
   const params = useParams<PathParams>();
-  if (!params) {
+  if (!params?.baseSymbol || !params.quoteSymbol) {
     throw new Error('No symbol params in path');
   }
   return { baseSymbol: params.baseSymbol, quoteSymbol: params.quoteSymbol };

--- a/src/pages/trade/model/use-prefetch-summary.ts
+++ b/src/pages/trade/model/use-prefetch-summary.ts
@@ -1,0 +1,33 @@
+import { PathParams } from '@/pages/trade/model/use-path';
+import { getSummary } from '@/shared/api/server/summary';
+import { DurationWindow } from '@/shared/utils/duration.ts';
+import { getQueryClient } from '@/shared/const/queryClient';
+import { useServerParams } from '@/shared/utils/server-params';
+
+export const usePrefetchSummary = (window: DurationWindow) => {
+  const queryClient = getQueryClient();
+  const { baseSymbol, quoteSymbol } = useServerParams<PathParams>();
+
+  return () =>
+    queryClient.prefetchQuery({
+      queryKey: ['summary', baseSymbol, quoteSymbol],
+      queryFn: async () => {
+        const paramsObj = {
+          durationWindow: window,
+          baseAsset: baseSymbol,
+          quoteAsset: quoteSymbol,
+        };
+        const baseUrl = 'https://localhost/api/summary';
+        const urlParams = new URLSearchParams(paramsObj).toString();
+        const res = await getSummary({ url: `${baseUrl}?${urlParams}` });
+        if ('error' in res) {
+          throw new Error(res.error);
+        }
+        return {
+          ...res,
+          asset_start: res.asset_start.toJSON(),
+          asset_end: res.asset_end.toJSON(),
+        };
+      },
+    });
+};

--- a/src/pages/trade/model/use-prefetch-summary.ts
+++ b/src/pages/trade/model/use-prefetch-summary.ts
@@ -8,26 +8,29 @@ export const usePrefetchSummary = (window: DurationWindow) => {
   const queryClient = getQueryClient();
   const { baseSymbol, quoteSymbol } = useServerParams<PathParams>();
 
-  return () =>
-    queryClient.prefetchQuery({
-      queryKey: ['summary', baseSymbol, quoteSymbol],
-      queryFn: async () => {
-        const paramsObj = {
-          durationWindow: window,
-          baseAsset: baseSymbol,
-          quoteAsset: quoteSymbol,
-        };
-        const baseUrl = 'https://localhost/api/summary';
-        const urlParams = new URLSearchParams(paramsObj).toString();
-        const res = await getSummary({ url: `${baseUrl}?${urlParams}` });
-        if ('error' in res) {
-          throw new Error(res.error);
-        }
-        return {
-          ...res,
-          asset_start: res.asset_start.toJSON(),
-          asset_end: res.asset_end.toJSON(),
-        };
-      },
-    });
+  return {
+    queryClient,
+    prefetch: () =>
+      queryClient.prefetchQuery({
+        queryKey: ['summary', baseSymbol, quoteSymbol],
+        queryFn: async () => {
+          const paramsObj = {
+            durationWindow: window,
+            baseAsset: baseSymbol,
+            quoteAsset: quoteSymbol,
+          };
+          const baseUrl = 'https://localhost/api/summary';
+          const urlParams = new URLSearchParams(paramsObj).toString();
+          const res = await getSummary({ url: `${baseUrl}?${urlParams}` });
+          if ('error' in res) {
+            throw new Error(res.error);
+          }
+          return {
+            ...res,
+            asset_start: res.asset_start.toJSON(),
+            asset_end: res.asset_end.toJSON(),
+          };
+        },
+      }),
+  };
 };

--- a/src/pages/trade/model/use-summary.ts
+++ b/src/pages/trade/model/use-summary.ts
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
-import { usePathSymbols } from '@/pages/trade/model/use-path.ts';
-import { SummaryResponse } from '@/shared/api/server/summary.ts';
+import { usePathSymbols } from '@/pages/trade/model/use-path';
+import { SummaryResponse } from '@/shared/api/server/summary';
 import { DurationWindow } from '@/shared/utils/duration.ts';
 
 export const useSummary = (window: DurationWindow) => {

--- a/src/pages/trade/ui/chart.tsx
+++ b/src/pages/trade/ui/chart.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import cn from 'clsx';
 import { useEffect, useRef, useState } from 'react';
 import { createChart, IChartApi, OhlcData } from 'lightweight-charts';

--- a/src/pages/trade/ui/form-tabs.tsx
+++ b/src/pages/trade/ui/form-tabs.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { useState } from 'react';
 import { useAutoAnimate } from '@formkit/auto-animate/react';
 import { Tabs } from '@penumbra-zone/ui/Tabs';

--- a/src/pages/trade/ui/history-tabs.tsx
+++ b/src/pages/trade/ui/history-tabs.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { useState } from 'react';
 import { useAutoAnimate } from '@formkit/auto-animate/react';
 import { Tabs } from '@penumbra-zone/ui/Tabs';

--- a/src/pages/trade/ui/page-layout.tsx
+++ b/src/pages/trade/ui/page-layout.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import cn from 'clsx';
 import { PairInfo } from './pair-info';
 import { Chart } from './chart';

--- a/src/pages/trade/ui/page-layout.tsx
+++ b/src/pages/trade/ui/page-layout.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import cn from 'clsx';
+import { PairInfo } from './pair-info';
+import { Chart } from './chart';
+import { RouteTabs } from './route-tabs';
+import { TradesTabs } from './trades-tabs';
+import { HistoryTabs } from './history-tabs';
+import { FormTabs } from './form-tabs';
+
+export const TradePageLayout = () => {
+  return (
+    <div
+      className={cn(
+        'grid w-full border-t border-t-other-solidStroke overflow-x-hidden',
+        // mobile grid
+        'grid-cols-[100%] grid-rows-[auto,auto,auto,auto,auto]',
+        // tablet grid (600px)
+        'tablet:grid-cols-[50%,50%] tablet:grid-rows-[auto,auto,auto,auto]',
+        // desktop grid (>900px)
+        'desktop:grid-cols-[1fr,1fr,300px] desktop:grid-rows-[auto,652px,auto,auto]',
+        // large grid (>1200px)
+        'lg:grid-cols-[1fr,320px,320px] lg:grid-rows-[auto,660px,auto]',
+        // extra large grid (>1600px)
+        'xl:grid-cols-[1fr,320px,320px] xl:grid-rows-[auto,660px,auto]',
+      )}
+    >
+      <div className='row-start-1 tablet:col-span-2 desktop:col-span-3 xl:col-span-1 border-b border-b-other-solidStroke xl:border-r xl:border-r-other-solidStroke'>
+        <PairInfo />
+      </div>
+
+      <div className='hidden desktop:block desktop:row-start-2 desktop:col-span-2 lg:col-span-1 border-b border-b-other-solidStroke desktop:border-r desktop:border-r-other-solidStroke'>
+        <Chart />
+      </div>
+
+      <div className='row-start-3 tablet:col-start-2 desktop:row-start-2 desktop:col-start-3 desktop:row-span-2 lg:row-span-1 xl:row-span-2 border-b border-b-other-solidStroke desktop:border-l desktop:border-l-other-solidStroke'>
+        <FormTabs />
+      </div>
+
+      <div className='row-start-4 tablet:row-start-3 lg:row-start-2 lg:col-start-2 xl:row-start-1 xl:row-span-2 border-b border-b-other-solidStroke tablet:border-r tablet:border-r-other-solidStroke lg:border-r-0'>
+        <RouteTabs />
+      </div>
+
+      <div className='row-start-2 tablet:col-span-2 desktop:hidden border-b border-b-other-solidStroke'>
+        <TradesTabs withChart />
+      </div>
+      <div className='hidden desktop:block desktop:row-start-3 desktop:col-start-2 lg:col-start-3 desktop:border-b desktop:border-b-other-solidStroke lg:border-l lg:border-l-other-solidStroke'>
+        <TradesTabs />
+      </div>
+
+      <div className='row-start-5 tablet:row-start-4 tablet:col-span-2 desktop:col-span-3 lg:row-start-3 lg:col-start-1 lg:col-span-2 border-b border-b-other-solidStroke'>
+        <HistoryTabs />
+      </div>
+    </div>
+  );
+};

--- a/src/pages/trade/ui/page.tsx
+++ b/src/pages/trade/ui/page.tsx
@@ -2,7 +2,6 @@ import { TradePageLayout } from './page-layout';
 import { usePrefetchSummary } from '../model/use-prefetch-summary';
 import { HydrationBoundary, dehydrate } from '@tanstack/react-query';
 import { setServerParams } from '@/shared/utils/server-params';
-import { getQueryClient } from '@/shared/const/queryClient';
 
 interface TradePageParams {
   baseSymbol: string;
@@ -13,11 +12,11 @@ export const TradePage = async (props: { params: Promise<TradePageParams> }) => 
   setServerParams(await props.params);
 
   // eslint-disable-next-line react-hooks/rules-of-hooks -- in server components it is fine to use async hooks
-  const prefetch = usePrefetchSummary('1d');
+  const { prefetch, queryClient } = usePrefetchSummary('1d');
   await prefetch();
 
   return (
-    <HydrationBoundary state={dehydrate(getQueryClient())}>
+    <HydrationBoundary state={dehydrate(queryClient)}>
       <TradePageLayout />
     </HydrationBoundary>
   );

--- a/src/pages/trade/ui/page.tsx
+++ b/src/pages/trade/ui/page.tsx
@@ -1,56 +1,24 @@
-'use client';
+import { TradePageLayout } from './page-layout';
+import { usePrefetchSummary } from '../model/use-prefetch-summary';
+import { HydrationBoundary, dehydrate } from '@tanstack/react-query';
+import { setServerParams } from '@/shared/utils/server-params';
+import { getQueryClient } from '@/shared/const/queryClient';
 
-import cn from 'clsx';
-import { PairInfo } from './pair-info';
-import { Chart } from './chart';
-import { RouteTabs } from './route-tabs';
-import { TradesTabs } from './trades-tabs';
-import { HistoryTabs } from './history-tabs';
-import { FormTabs } from './form-tabs';
+interface TradePageParams {
+  baseSymbol: string;
+  quoteSymbol: string;
+}
 
-export const TradePage = () => {
+export const TradePage = async (props: { params: Promise<TradePageParams> }) => {
+  setServerParams(await props.params);
+
+  // eslint-disable-next-line react-hooks/rules-of-hooks -- in server components it is fine to use async hooks
+  const prefetch = usePrefetchSummary('1d');
+  await prefetch();
+
   return (
-    <div
-      className={cn(
-        'grid w-full border-t border-t-other-solidStroke overflow-x-hidden',
-        // mobile grid
-        'grid-cols-[100%] grid-rows-[auto,auto,auto,auto,auto]',
-        // tablet grid (600px)
-        'tablet:grid-cols-[50%,50%] tablet:grid-rows-[auto,auto,auto,auto]',
-        // desktop grid (>900px)
-        'desktop:grid-cols-[1fr,1fr,300px] desktop:grid-rows-[auto,652px,auto,auto]',
-        // large grid (>1200px)
-        'lg:grid-cols-[1fr,320px,320px] lg:grid-rows-[auto,660px,auto]',
-        // extra large grid (>1600px)
-        'xl:grid-cols-[1fr,320px,320px] xl:grid-rows-[auto,660px,auto]',
-      )}
-    >
-      <div className='row-start-1 tablet:col-span-2 desktop:col-span-3 xl:col-span-1 border-b border-b-other-solidStroke xl:border-r xl:border-r-other-solidStroke'>
-        <PairInfo />
-      </div>
-
-      <div className='hidden desktop:block desktop:row-start-2 desktop:col-span-2 lg:col-span-1 border-b border-b-other-solidStroke desktop:border-r desktop:border-r-other-solidStroke'>
-        <Chart />
-      </div>
-
-      <div className='row-start-3 tablet:col-start-2 desktop:row-start-2 desktop:col-start-3 desktop:row-span-2 lg:row-span-1 xl:row-span-2 border-b border-b-other-solidStroke desktop:border-l desktop:border-l-other-solidStroke'>
-        <FormTabs />
-      </div>
-
-      <div className='row-start-4 tablet:row-start-3 lg:row-start-2 lg:col-start-2 xl:row-start-1 xl:row-span-2 border-b border-b-other-solidStroke tablet:border-r tablet:border-r-other-solidStroke lg:border-r-0'>
-        <RouteTabs />
-      </div>
-
-      <div className='row-start-2 tablet:col-span-2 desktop:hidden border-b border-b-other-solidStroke'>
-        <TradesTabs withChart />
-      </div>
-      <div className='hidden desktop:block desktop:row-start-3 desktop:col-start-2 lg:col-start-3 desktop:border-b desktop:border-b-other-solidStroke lg:border-l lg:border-l-other-solidStroke'>
-        <TradesTabs />
-      </div>
-
-      <div className='row-start-5 tablet:row-start-4 tablet:col-span-2 desktop:col-span-3 lg:row-start-3 lg:col-start-1 lg:col-span-2 border-b border-b-other-solidStroke'>
-        <HistoryTabs />
-      </div>
-    </div>
+    <HydrationBoundary state={dehydrate(getQueryClient())}>
+      <TradePageLayout />
+    </HydrationBoundary>
   );
 };

--- a/src/pages/trade/ui/route-tabs.tsx
+++ b/src/pages/trade/ui/route-tabs.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { useState } from 'react';
 import { useAutoAnimate } from '@formkit/auto-animate/react';
 import { Tabs } from '@penumbra-zone/ui/Tabs';

--- a/src/pages/trade/ui/summary.tsx
+++ b/src/pages/trade/ui/summary.tsx
@@ -1,10 +1,12 @@
+'use client';
+
 import { ReactNode } from 'react';
 import cn from 'clsx';
 import { useAutoAnimate } from '@formkit/auto-animate/react';
 import { Text } from '@penumbra-zone/ui/Text';
 import { AssetIcon } from '@penumbra-zone/ui/AssetIcon';
 import { Skeleton } from '@/shared/ui/skeleton';
-import { useSummary } from '../model/useSummary';
+import { useSummary } from '../model/use-summary';
 import { usePathToMetadata } from '../model/use-path';
 import { shortify } from '@/shared/utils/numbers/shortify';
 import { round } from '@/shared/utils/numbers/round';

--- a/src/pages/trade/ui/trades-tabs.tsx
+++ b/src/pages/trade/ui/trades-tabs.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { useState } from 'react';
 import { ChevronDown, ChevronUp } from 'lucide-react';
 import { useAutoAnimate } from '@formkit/auto-animate/react';

--- a/src/shared/api/compact-block.ts
+++ b/src/shared/api/compact-block.ts
@@ -5,7 +5,7 @@ import { CompactBlockService, TendermintProxyService } from '@penumbra-zone/prot
 import { createPromiseClient, Transport } from '@connectrpc/connect';
 import { errorIsStreamAbort, useStream } from '@/shared/use-stream.ts';
 import { useCallback, useEffect } from 'react';
-import { queryClient } from '@/shared/const/queryClient.ts';
+import { getQueryClient } from '@/shared/const/queryClient.ts';
 import { useGrpcTransport } from '@/shared/api/transport.ts';
 
 const fetchLatestBlockHeight = async (transport: Transport) => {
@@ -30,7 +30,7 @@ const startBlockHeightStream = async (transport: Transport, signal: AbortSignal)
     )) {
       if (response.compactBlock?.height) {
         const newHeight = Number(response.compactBlock.height);
-        queryClient.setQueryData(LATEST_HEIGHT_QUERY_KEY, newHeight);
+        getQueryClient().setQueryData(LATEST_HEIGHT_QUERY_KEY, newHeight);
       }
     }
   } catch (error) {

--- a/src/shared/api/server/summary.ts
+++ b/src/shared/api/server/summary.ts
@@ -4,63 +4,63 @@ import { ChainRegistryClient } from '@penumbra-labs/registry';
 import { DexExPairsSummary } from '@/shared/database/schema.ts';
 import { durationWindows, isDurationWindow } from '@/shared/utils/duration.ts';
 
-export type SummaryResponse = DexExPairsSummary | { error: string };
+export type SummaryResponse = DexExPairsSummary | { error: string; status: number };
 
-export async function GET(req: NextRequest): Promise<NextResponse<SummaryResponse>> {
+export const getSummary = async (req: { url: string }): Promise<SummaryResponse> => {
   const chainId = process.env['PENUMBRA_CHAIN_ID'];
   if (!chainId) {
-    return NextResponse.json({ error: 'PENUMBRA_CHAIN_ID is not set' }, { status: 500 });
+    return { error: 'PENUMBRA_CHAIN_ID is not set', status: 500 };
   }
 
-  const { searchParams } = new URL(req.url);
-  const baseAssetSymbol = searchParams.get('baseAsset');
-  const quoteAssetSymbol = searchParams.get('quoteAsset');
-  if (!baseAssetSymbol || !quoteAssetSymbol) {
-    return NextResponse.json(
-      { error: 'Missing required baseAsset or quoteAsset' },
-      { status: 400 },
+  try {
+    const { searchParams } = new URL(req.url);
+    const baseAssetSymbol = searchParams.get('baseAsset');
+    const quoteAssetSymbol = searchParams.get('quoteAsset');
+    if (!baseAssetSymbol || !quoteAssetSymbol) {
+      return { error: 'Missing required baseAsset or quoteAsset', status: 400 };
+    }
+
+    const durationWindow = searchParams.get('durationWindow');
+    if (!durationWindow || !isDurationWindow(durationWindow)) {
+      return {
+        error: `durationWindow missing or invalid window. Options: ${durationWindows.join(', ')}`,
+        status: 400,
+      };
+    }
+
+    const registryClient = new ChainRegistryClient();
+    const registry = await registryClient.remote.get(chainId);
+
+    // TODO: Add getMetadataBySymbol() helper to registry npm package
+    const allAssets = registry.getAllAssets();
+    const baseAssetMetadata = allAssets.find(
+      a => a.symbol.toLowerCase() === baseAssetSymbol.toLowerCase(),
     );
-  }
-
-  const durationWindow = searchParams.get('durationWindow');
-  if (!durationWindow || !isDurationWindow(durationWindow)) {
-    return NextResponse.json(
-      { error: `durationWindow missing or invalid window. Options: ${durationWindows.join(', ')}` },
-      { status: 400 },
+    const quoteAssetMetadata = allAssets.find(
+      a => a.symbol.toLowerCase() === quoteAssetSymbol.toLowerCase(),
     );
-  }
+    if (!baseAssetMetadata?.penumbraAssetId || !quoteAssetMetadata?.penumbraAssetId) {
+      return { error: `Base asset or quoteAsset assetId not found in registry`, status: 400 };
+    }
 
-  const registryClient = new ChainRegistryClient();
-  const registry = await registryClient.remote.get(chainId);
-
-  // TODO: Add getMetadataBySymbol() helper to registry npm package
-  const allAssets = registry.getAllAssets();
-  const baseAssetMetadata = allAssets.find(
-    a => a.symbol.toLowerCase() === baseAssetSymbol.toLowerCase(),
-  );
-  const quoteAssetMetadata = allAssets.find(
-    a => a.symbol.toLowerCase() === quoteAssetSymbol.toLowerCase(),
-  );
-  if (!baseAssetMetadata?.penumbraAssetId || !quoteAssetMetadata?.penumbraAssetId) {
-    return NextResponse.json(
-      { error: `Base asset or quoteAsset assetId not found in registry` },
-      { status: 400 },
+    const results = await pindexer.summary(
+      durationWindow,
+      baseAssetMetadata.penumbraAssetId,
+      quoteAssetMetadata.penumbraAssetId,
     );
+
+    const summary = results[0];
+    if (!summary) {
+      return { error: `No summary found for ${baseAssetSymbol}/${quoteAssetSymbol}`, status: 400 };
+    }
+
+    return summary;
+  } catch (error) {
+    return { error: String(error), status: 500 };
   }
+};
 
-  const results = await pindexer.summary(
-    durationWindow,
-    baseAssetMetadata.penumbraAssetId,
-    quoteAssetMetadata.penumbraAssetId,
-  );
-
-  const summary = results[0];
-  if (!summary) {
-    return NextResponse.json(
-      { error: `No summary found for ${baseAssetSymbol}/${quoteAssetSymbol}` },
-      { status: 400 },
-    );
-  }
-
-  return NextResponse.json(summary);
-}
+export const GET = async (req: NextRequest): Promise<NextResponse<SummaryResponse>> => {
+  const res = await getSummary(req);
+  return NextResponse.json(res, { status: 'error' in res ? res.status : 200 });
+};

--- a/src/shared/const/queryClient.ts
+++ b/src/shared/const/queryClient.ts
@@ -1,3 +1,33 @@
-import { QueryClient } from '@tanstack/react-query';
+import { isServer, QueryClient } from '@tanstack/react-query';
+import { cache } from 'react';
 
-export const queryClient = new QueryClient();
+const makeQueryClient = () => {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        // With SSR, we usually want to set some default staleTime
+        // above 0 to avoid refetching immediately on the client
+        staleTime: 60 * 1000,
+      },
+    },
+  });
+};
+
+const serverClient =  cache(() => makeQueryClient());
+let browserQueryClient: QueryClient | undefined = undefined;
+
+export const getQueryClient = () => {
+  if (isServer) {
+    // Server: always make a new query client
+    return serverClient();
+  } else {
+    // Browser: make a new query client if we don't already have one
+    // This is very important, so we don't re-make a new client if React
+    // suspends during the initial render. This may not be needed if we
+    // have a suspense boundary BELOW the creation of the query client
+    if (!browserQueryClient) {
+      browserQueryClient = makeQueryClient();
+    }
+    return browserQueryClient;
+  }
+};

--- a/src/shared/const/queryClient.ts
+++ b/src/shared/const/queryClient.ts
@@ -1,5 +1,4 @@
 import { isServer, QueryClient } from '@tanstack/react-query';
-import { cache } from 'react';
 
 const makeQueryClient = () => {
   return new QueryClient({
@@ -13,13 +12,12 @@ const makeQueryClient = () => {
   });
 };
 
-const serverClient =  cache(() => makeQueryClient());
 let browserQueryClient: QueryClient | undefined = undefined;
 
 export const getQueryClient = () => {
   if (isServer) {
     // Server: always make a new query client
-    return serverClient();
+    return makeQueryClient();
   } else {
     // Browser: make a new query client if we don't already have one
     // This is very important, so we don't re-make a new client if React

--- a/src/shared/utils/server-params.ts
+++ b/src/shared/utils/server-params.ts
@@ -1,0 +1,16 @@
+import { cache } from 'react';
+
+const serverContext = cache<() => { params: object }>(() => ({
+  params: {},
+}));
+
+/**
+ * TODO: docs
+ */
+export const useServerParams = <T extends object>() => {
+  return serverContext().params as T;
+};
+
+export const setServerParams = <T extends object>(params: T) => {
+  serverContext().params = params;
+};


### PR DESCRIPTION
Fixes #143 

⚠️ EXPERIMENTAL

This is a draft of moving data request on server. So far it looks like too much work. All of the changed code only moves the `summary` request to server components. This is how it works:
1. When a user types the URL, the browser then sends the URL to our server
2. The server tries to pre-render the HTML string of the server components
3. It makes the request to the `summary` 
4. The result of this request is used to render the html without `isLoading` in react query. If user has JavaScript disabled in their browser, it would render the html of the summary block normally, without any skeleton loaders
5. The serialized data of the request is also sent to the browser via react-query's `HydrationBoundary` component. See the screenshot below – it shows how react-query populates the html with the server-side data that is then taken by the client
6. When the client component `Summary` tries to `useQuery`, it takes the data from the server instead of making the new request

Now, what do you think of this approach? Should we continue investigating the best pattern of server-side request?

<img width="1512" alt="Screenshot 2024-11-21 at 16 26 13" src="https://github.com/user-attachments/assets/d9a84c9e-3625-4b26-87a6-75c0147dd52e">
