### PR TITLE
candles: rely on database for symmetrization, fill empty candles

### DIFF
--- a/src/pages/trade/api/candles.tsx
+++ b/src/pages/trade/api/candles.tsx
@@ -2,8 +2,8 @@ import { useQuery } from '@tanstack/react-query';
 import { useRefetchOnNewBlock } from '@/shared/api/compact-block.ts';
 import { CandleApiResponse } from '@/shared/api/server/candles/types.ts';
 import { usePathSymbols } from '@/pages/trade/model/use-path.ts';
-import { OhlcData } from 'lightweight-charts';
-import { DurationWindow } from '@/shared/utils/duration.ts';
+import { OhlcData, UTCTimestamp } from 'lightweight-charts';
+import { addDurationWindow, DurationWindow } from '@/shared/utils/duration.ts';
 
 export const useCandles = (durationWindow: DurationWindow) => {
   const { baseSymbol, quoteSymbol } = usePathSymbols();
@@ -22,6 +22,36 @@ export const useCandles = (durationWindow: DurationWindow) => {
       const jsonRes = (await res.json()) as CandleApiResponse;
       if ('error' in jsonRes) {
         throw new Error(jsonRes.error);
+      }
+      const out: OhlcData<UTCTimestamp>[] = [];
+      let i = 0;
+      while (i < jsonRes.length) {
+        const candle = jsonRes[i];
+        if (!candle) {
+          break;
+        }
+        if (out.length > 0) {
+          const prev = out[out.length - 1];
+          if (!prev) {
+            throw new Error('the impossible happened');
+          }
+          const nextTime = (addDurationWindow(
+            durationWindow,
+            new Date(prev.time * 1000),
+          ).getTime() / 1000) as UTCTimestamp;
+          if (nextTime < candle.time) {
+            out.push({
+              time: nextTime,
+              open: prev.close,
+              close: prev.close,
+              low: prev.close,
+              high: prev.close,
+            });
+            continue;
+          }
+        }
+        out.push(candle);
+        i += 1;
       }
       return jsonRes;
     },

--- a/src/shared/api/server/candles/index.ts
+++ b/src/shared/api/server/candles/index.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { ChainRegistryClient } from '@penumbra-labs/registry';
 import { pindexer } from '@/shared/database';
 import { CandleApiResponse } from '@/shared/api/server/candles/types.ts';
-import { dbCandleToOhlc, mergeCandles } from '@/shared/api/server/candles/utils.ts';
+import { dbCandleToOhlc } from '@/shared/api/server/candles/utils.ts';
 import { durationWindows, isDurationWindow } from '@/shared/utils/duration.ts';
 
 export async function GET(req: NextRequest): Promise<NextResponse<CandleApiResponse>> {
@@ -51,25 +51,14 @@ export async function GET(req: NextRequest): Promise<NextResponse<CandleApiRespo
   }
 
   // Need to query both directions and aggregate results
-  const candlesFwd = await pindexer.candles({
+  const candles = await pindexer.candles({
     baseAsset: baseAssetMetadata.penumbraAssetId,
     quoteAsset: quoteAssetMetadata.penumbraAssetId,
     window: durationWindow,
     chainId,
   });
-  const candlesReverse = await pindexer.candles({
-    baseAsset: quoteAssetMetadata.penumbraAssetId,
-    quoteAsset: baseAssetMetadata.penumbraAssetId,
-    window: durationWindow,
-    chainId,
-  });
 
-  const mergedCandles = mergeCandles(
-    { metadata: baseAssetMetadata, candles: candlesFwd },
-    { metadata: quoteAssetMetadata, candles: candlesReverse },
-  );
-
-  const response = mergedCandles.map(dbCandleToOhlc);
+  const response = candles.map(dbCandleToOhlc);
 
   return NextResponse.json(response);
 }

--- a/src/shared/api/server/candles/types.ts
+++ b/src/shared/api/server/candles/types.ts
@@ -1,6 +1,6 @@
-import { OhlcData } from 'lightweight-charts';
+import { OhlcData, UTCTimestamp } from 'lightweight-charts';
 
-export type CandleApiResponse = OhlcData[] | { error: string };
+export type CandleApiResponse = OhlcData<UTCTimestamp>[] | { error: string };
 
 export interface DbCandle {
   close: number;

--- a/src/shared/api/server/candles/utils.ts
+++ b/src/shared/api/server/candles/utils.ts
@@ -1,9 +1,7 @@
 import { OhlcData, UTCTimestamp } from 'lightweight-charts';
 import { DbCandle } from '@/shared/api/server/candles/types.ts';
-import { Metadata } from '@penumbra-zone/protobuf/penumbra/core/asset/v1/asset_pb';
-import { getDisplayDenomExponent } from '@penumbra-zone/getters/metadata';
 
-export const dbCandleToOhlc = (c: DbCandle): OhlcData => {
+export const dbCandleToOhlc = (c: DbCandle): OhlcData<UTCTimestamp> => {
   return {
     close: c.close,
     high: c.high,
@@ -11,78 +9,4 @@ export const dbCandleToOhlc = (c: DbCandle): OhlcData => {
     open: c.open,
     time: (c.start_time.getTime() / 1000) as UTCTimestamp,
   };
-};
-
-const mergeCandle = (candle1: DbCandle, candle2: DbCandle): DbCandle => {
-  const mergedCandle = { ...candle1 };
-
-  // OHLC should be weighted average
-  const candle1TotalVolume = candle1.swap_volume + candle1.direct_volume;
-  const candle2TotalVolume = candle2.swap_volume + candle2.direct_volume;
-
-  mergedCandle.open =
-    (candle1.open * candle1TotalVolume + candle2.open * candle2TotalVolume) /
-    (candle1TotalVolume + candle2TotalVolume);
-  mergedCandle.close =
-    (candle1.close * candle1TotalVolume + candle2.close * candle2TotalVolume) /
-    (candle1TotalVolume + candle2TotalVolume);
-
-  mergedCandle.high = Math.max(candle1.high, candle2.high);
-  mergedCandle.low = Math.min(candle1.low, candle2.low);
-
-  mergedCandle.swap_volume = candle1.swap_volume + candle2.swap_volume;
-  mergedCandle.direct_volume = candle1.direct_volume + candle2.direct_volume;
-
-  return mergedCandle;
-};
-
-interface CandleSet {
-  metadata: Metadata;
-  candles: DbCandle[];
-}
-
-// Should be reversed to be in terms of base asset
-const normalizeQuoteCandles = (base: CandleSet, quote: CandleSet): DbCandle[] => {
-  const baseExponent = getDisplayDenomExponent(base.metadata);
-  const quoteExponent = getDisplayDenomExponent(quote.metadata);
-  return quote.candles.map(prevCandle => {
-    const candle = { ...prevCandle };
-    candle.open = 1 / candle.open;
-    candle.close = 1 / candle.close;
-    candle.high = 1 / candle.high;
-    candle.low = 1 / candle.low;
-
-    // TODO: Adjust volumes based on price? But what price???
-    candle.swap_volume =
-      (candle.swap_volume * (1 / candle.close)) / 10 ** Math.abs(baseExponent - quoteExponent);
-    candle.direct_volume =
-      (candle.direct_volume * (1 / candle.close)) / 10 ** Math.abs(baseExponent - quoteExponent);
-
-    return candle;
-  });
-};
-
-export const mergeCandles = (base: CandleSet, quote: CandleSet): DbCandle[] => {
-  // If theres any data at the same height, combine them
-  const combinedDataMap = new Map<number, DbCandle>();
-  base.candles.forEach(candle => {
-    combinedDataMap.set(candle.start_time.getTime(), candle);
-  });
-
-  normalizeQuoteCandles(base, quote).forEach(candle => {
-    const utcTime = candle.start_time.getTime();
-    const entry = combinedDataMap.get(utcTime);
-    if (entry) {
-      const combinedCandle = mergeCandle(entry, candle);
-      combinedDataMap.set(utcTime, combinedCandle);
-    } else {
-      combinedDataMap.set(utcTime, candle);
-    }
-  });
-
-  const sortedCandles = Array.from(combinedDataMap.values()).sort((a, b) =>
-    a.start_time > b.start_time ? 1 : -1,
-  );
-
-  return sortedCandles;
 };

--- a/src/shared/database/index.ts
+++ b/src/shared/database/index.ts
@@ -61,7 +61,8 @@ class Pindexer {
       .select(['start_time', 'open', 'close', 'low', 'high', 'swap_volume', 'direct_volume'])
       .where('the_window', '=', window)
       .where('asset_start', '=', Buffer.from(baseAsset.inner))
-      .where('asset_end', '=', Buffer.from(quoteAsset.inner));
+      .where('asset_end', '=', Buffer.from(quoteAsset.inner))
+      .orderBy('start_time', 'asc');
 
     // Due to a lot of price volatility at the launch of the chain, manually setting start date a few days later
     if (chainId === MAINNET_CHAIN_ID) {

--- a/src/shared/utils/duration.ts
+++ b/src/shared/utils/duration.ts
@@ -2,3 +2,31 @@ export const durationWindows = ['1m', '15m', '1h', '4h', '1d', '1w', '1mo'] as c
 export type DurationWindow = (typeof durationWindows)[number];
 export const isDurationWindow = (str: string): str is DurationWindow =>
   durationWindows.includes(str as DurationWindow);
+
+export const addDurationWindow = (window: DurationWindow, to: Date): Date => {
+  const out = new Date(to);
+  switch (window) {
+    case '1m':
+      out.setMinutes(to.getMinutes() + 1);
+      break;
+    case '15m':
+      out.setMinutes(to.getMinutes() + 15);
+      break;
+    case '1h':
+      out.setHours(to.getHours() + 1);
+      break;
+    case '4h':
+      out.setHours(to.getHours() + 4);
+      break;
+    case '1d':
+      out.setDate(to.getDate() + 1);
+      break;
+    case '1w':
+      out.setDate(to.getDate() + 7);
+      break;
+    case '1mo':
+      out.setMonth(to.getMonth() + 1);
+      break;
+  }
+  return out;
+};


### PR DESCRIPTION
Closes https://github.com/penumbra-zone/dex-explorer/issues/148
Closes https://github.com/penumbra-zone/dex-explorer/issues/151

This changes the logic to rely on the database to integrate price information for both directions, which simplifies the logic on our end, and makes us correctly integrate tweaks to this logic without needing changes.

This also fills empty candles in between the start and end dates of the candles provided by the database.