### PR TITLE
fix: routebook visual updates

### DIFF
--- a/src/pages/trade/ui/route-book.tsx
+++ b/src/pages/trade/ui/route-book.tsx
@@ -61,12 +61,8 @@ const RouteBookData = observer(({ bookData }: { bookData?: RouteBookResponse }) 
     <div className='w-full'>
       {/* Header */}
       <div className='grid grid-cols-[1fr_1fr_1fr_1fr] h-[33px] mt-1 text-xs text-gray-400 px-4'>
-        <div className='py-2 font-normal text-left'>
-          Price({pair.quoteSymbol})
-        </div>
-        <div className='py-2 font-normal text-right'>
-          Amount({pair.baseSymbol})
-        </div>
+        <div className='py-2 font-normal text-left'>Price({pair.quoteSymbol})</div>
+        <div className='py-2 font-normal text-right'>Amount({pair.baseSymbol})</div>
         <div className='py-2 font-normal text-right'>Total</div>
         <div className='py-2 font-normal text-right'>Route</div>
       </div>

--- a/src/pages/trade/ui/route-book.tsx
+++ b/src/pages/trade/ui/route-book.tsx
@@ -5,35 +5,49 @@ import { RouteBookResponse, Trace } from '@/shared/api/server/book/types';
 import { usePathSymbols } from '@/pages/trade/model/use-path.ts';
 import { calculateSpread } from '@/pages/trade/model/trace.ts';
 import { TradeRow } from '@/pages/trade/ui/trade-row.tsx';
+import { Skeleton } from '@/shared/ui/skeleton';
 
 const SkeletonRow = (props: { isSpread: boolean }) =>
   props.isSpread ? (
     <tr>
       <td colSpan={4} className='border-y border-l-other-solidStroke'>
         <div className='flex items-center justify-center gap-2 px-3 py-3 text-xs'>
-          <div className='w-full h-[22px] bg-neutral-800 rounded animate-pulse ml-auto'></div>
-
-          <div className='w-full h-[22px] bg-neutral-800 rounded animate-pulse ml-auto'></div>
-
-          <div className='w-full h-[22px] bg-neutral-800 rounded animate-pulse ml-auto'></div>
-
-          <div className='w-full h-[22px] bg-neutral-800 rounded animate-pulse ml-auto'></div>
+          <div className='w-[78px] h-[16px]'>
+            <Skeleton />
+          </div>
+          <div className='w-[54px] h-[16px]'>
+            <Skeleton />
+          </div>
+          <div className='w-[69px] h-[16px]'>
+            <Skeleton />
+          </div>
+          <div className='w-[39px] h-[16px]'>
+            <Skeleton />
+          </div>
         </div>
       </td>
     </tr>
   ) : (
     <tr className={`group relative h-[33px] border-b border-b-other-tonalStroke`}>
-      <td>
-        <div className='w-full h-[22px] bg-neutral-800 rounded animate-pulse ml-auto'></div>
+      <td className='pl-4'>
+        <div className='w-[56px] h-[16px]'>
+          <Skeleton />
+        </div>
       </td>
-      <td className='relative text-xs text-right text-white'>
-        <div className='w-full h-[22px] bg-neutral-800 rounded animate-pulse ml-auto'></div>
+      <td className='relative text-xs text-right pl-4'>
+        <div className='w-[56px] h-[16px] ml-auto'>
+          <Skeleton />
+        </div>
       </td>
-      <td className='relative text-xs text-right text-white'>
-        <div className='w-full h-[22px] bg-neutral-800 rounded animate-pulse ml-auto'></div>
+      <td className='relative text-xs text-right pl-4'>
+        <div className='w-[56px] h-[16px] ml-auto'>
+          <Skeleton />
+        </div>
       </td>
-      <td className='relative text-xs text-right'>
-        <div className='w-full h-[22px] bg-neutral-800 rounded animate-pulse ml-auto'></div>
+      <td className='relative text-xs text-right pl-4'>
+        <div className='w-[24px] h-[16px] ml-auto'>
+          <Skeleton />
+        </div>
       </td>
     </tr>
   );
@@ -49,10 +63,10 @@ const RouteBookData = observer(({ bookData }: { bookData?: RouteBookResponse }) 
     <table className='w-full'>
       <thead>
         <tr className='text-xs text-gray-400'>
-          <th className='px-4 py-2 font-normal text-left'>Price({pair.quoteSymbol})</th>
-          <th className='px-4 py-2 font-normal text-right'>Amount({pair.baseSymbol})</th>
-          <th className='px-4 py-2 font-normal text-right'>Total</th>
-          <th className='px-4 py-2 font-normal text-right'>Route</th>
+          <th className='pl-4 py-2 font-normal text-left'>Price({pair.quoteSymbol})</th>
+          <th className='pl-4 py-2 font-normal text-right'>Amount({pair.baseSymbol})</th>
+          <th className='pl-4 py-2 font-normal text-right'>Total</th>
+          <th className='pl-4 py-2 font-normal text-right'>Route</th>
         </tr>
       </thead>
 
@@ -99,6 +113,22 @@ export const RouteBook = observer(() => {
   return <RouteBookData bookData={data} />;
 });
 
+function formatPrice(price: string): string {
+  const num = parseFloat(price);
+  const [whole] = num.toString().split('.');
+  const totalDigits = 7;
+  const availableDecimals = Math.max(0, totalDigits - (whole?.length ?? 0));
+  return num.toFixed(availableDecimals);
+}
+
+function formatNumber(value: string): string {
+  const num = parseFloat(value);
+  const [whole] = num.toString().split('.');
+  const totalDigits = 6;
+  const availableDecimals = Math.max(0, totalDigits - (whole?.length ?? 0));
+  return num.toFixed(availableDecimals);
+}
+
 const SpreadRow = ({ sellOrders, buyOrders }: { sellOrders: Trace[]; buyOrders: Trace[] }) => {
   const spreadInfo = calculateSpread(sellOrders, buyOrders);
   const pair = usePathSymbols();
@@ -111,12 +141,12 @@ const SpreadRow = ({ sellOrders, buyOrders }: { sellOrders: Trace[]; buyOrders: 
     <tr>
       <td colSpan={4} className='border-y border-y-other-solidStroke'>
         <div className='flex items-center justify-center gap-2 px-3 py-3 text-xs'>
-          <span className='text-green-400'>{parseFloat(spreadInfo.midPrice)}</span>
+          <span className='text-green-400'>{formatPrice(spreadInfo.midPrice)}</span>
           <span className='text-gray-400'>Spread:</span>
           <span className='text-white'>
-            {parseFloat(spreadInfo.amount)} {pair.quoteSymbol}
+            {formatNumber(spreadInfo.amount)} {pair.quoteSymbol}
           </span>
-          <span className='text-gray-400'>({spreadInfo.percentage}%)</span>
+          <span className='text-gray-400'>({parseFloat(spreadInfo.percentage).toFixed(2)}%)</span>
         </div>
       </td>
     </tr>

--- a/src/pages/trade/ui/route-book.tsx
+++ b/src/pages/trade/ui/route-book.tsx
@@ -9,47 +9,45 @@ import { Skeleton } from '@/shared/ui/skeleton';
 
 const SkeletonRow = (props: { isSpread: boolean }) =>
   props.isSpread ? (
-    <tr>
-      <td colSpan={4} className='border-y border-l-other-solidStroke'>
-        <div className='flex items-center justify-center gap-2 px-3 py-3 text-xs'>
-          <div className='w-[78px] h-[16px]'>
-            <Skeleton />
-          </div>
-          <div className='w-[54px] h-[16px]'>
-            <Skeleton />
-          </div>
-          <div className='w-[69px] h-[16px]'>
-            <Skeleton />
-          </div>
-          <div className='w-[39px] h-[16px]'>
-            <Skeleton />
-          </div>
+    <div className='border-y border-l-other-solidStroke'>
+      <div className='flex items-center justify-center gap-2 px-3 py-3 text-xs'>
+        <div className='w-[78px] h-[16px]'>
+          <Skeleton />
         </div>
-      </td>
-    </tr>
+        <div className='w-[54px] h-[16px]'>
+          <Skeleton />
+        </div>
+        <div className='w-[69px] h-[16px]'>
+          <Skeleton />
+        </div>
+        <div className='w-[39px] h-[16px]'>
+          <Skeleton />
+        </div>
+      </div>
+    </div>
   ) : (
-    <tr className={`group relative h-[33px] border-b border-b-other-tonalStroke`}>
-      <td className='pl-4'>
+    <div className='group relative h-[33px] border-b border-b-other-tonalStroke grid grid-cols-[1fr_1fr_1fr_1fr] items-center'>
+      <div className='pl-4'>
         <div className='w-[56px] h-[16px]'>
           <Skeleton />
         </div>
-      </td>
-      <td className='relative text-xs text-right pl-4'>
+      </div>
+      <div className='relative text-xs text-right pl-4'>
         <div className='w-[56px] h-[16px] ml-auto'>
           <Skeleton />
         </div>
-      </td>
-      <td className='relative text-xs text-right pl-4'>
+      </div>
+      <div className='relative text-xs text-right pl-4'>
         <div className='w-[56px] h-[16px] ml-auto'>
           <Skeleton />
         </div>
-      </td>
-      <td className='relative text-xs text-right pl-4'>
+      </div>
+      <div className='relative text-xs text-right pl-4'>
         <div className='w-[24px] h-[16px] ml-auto'>
           <Skeleton />
         </div>
-      </td>
-    </tr>
+      </div>
+    </div>
   );
 
 const RouteBookData = observer(({ bookData }: { bookData?: RouteBookResponse }) => {
@@ -60,21 +58,21 @@ const RouteBookData = observer(({ bookData }: { bookData?: RouteBookResponse }) 
   const buyRelativeSizes = calculateRelativeSizes(multiHops?.buy ?? []);
 
   return (
-    <table className='w-full'>
-      <thead>
-        <tr className='text-xs text-gray-400'>
-          <th className='pl-4 py-2 font-normal text-left w-[1%] whitespace-nowrap'>
-            Price({pair.quoteSymbol})
-          </th>
-          <th className='py-2 font-normal text-right w-[1%] whitespace-nowrap'>
-            Amount({pair.baseSymbol})
-          </th>
-          <th className='py-2 font-normal text-right w-[1%] whitespace-nowrap'>Total</th>
-          <th className='py-2 font-normal text-right w-[1%] whitespace-nowrap'>Route</th>
-        </tr>
-      </thead>
+    <div className='w-full'>
+      {/* Header */}
+      <div className='grid grid-cols-[1fr_1fr_1fr_1fr] h-[33px] mt-1 text-xs text-gray-400 px-4'>
+        <div className='py-2 font-normal text-left'>
+          Price({pair.quoteSymbol})
+        </div>
+        <div className='py-2 font-normal text-right'>
+          Amount({pair.baseSymbol})
+        </div>
+        <div className='py-2 font-normal text-right'>Total</div>
+        <div className='py-2 font-normal text-right'>Route</div>
+      </div>
 
-      <tbody className='relative'>
+      {/* Body */}
+      <div className='relative'>
         {multiHops ? (
           <>
             {multiHops.sell.map((trace, idx) => (
@@ -102,8 +100,8 @@ const RouteBookData = observer(({ bookData }: { bookData?: RouteBookResponse }) 
             .fill(1)
             .map((_, i) => <SkeletonRow isSpread={i === 8} key={i} />)
         )}
-      </tbody>
-    </table>
+      </div>
+    </div>
   );
 });
 
@@ -138,22 +136,20 @@ const SpreadRow = ({ sellOrders, buyOrders }: { sellOrders: Trace[]; buyOrders: 
   const pair = usePathSymbols();
 
   if (!spreadInfo) {
-    return;
+    return null;
   }
 
   return (
-    <tr>
-      <td colSpan={4} className='border-y border-y-other-solidStroke'>
-        <div className='flex items-center justify-center gap-2 px-3 py-3 text-xs'>
-          <span className='text-green-400'>{formatPrice(spreadInfo.midPrice)}</span>
-          <span className='text-gray-400'>Spread:</span>
-          <span className='text-white'>
-            {formatNumber(spreadInfo.amount)} {pair.quoteSymbol}
-          </span>
-          <span className='text-gray-400'>({parseFloat(spreadInfo.percentage).toFixed(2)}%)</span>
-        </div>
-      </td>
-    </tr>
+    <div className='border-b border-y-other-solidStroke'>
+      <div className='flex items-center justify-center gap-2 px-3 py-3 text-xs'>
+        <span className='text-green-400'>{formatPrice(spreadInfo.midPrice)}</span>
+        <span className='text-gray-400'>Spread:</span>
+        <span className='text-white'>
+          {formatNumber(spreadInfo.amount)} {pair.quoteSymbol}
+        </span>
+        <span className='text-gray-400'>({parseFloat(spreadInfo.percentage).toFixed(2)}%)</span>
+      </div>
+    </div>
   );
 };
 

--- a/src/pages/trade/ui/route-book.tsx
+++ b/src/pages/trade/ui/route-book.tsx
@@ -63,10 +63,14 @@ const RouteBookData = observer(({ bookData }: { bookData?: RouteBookResponse }) 
     <table className='w-full'>
       <thead>
         <tr className='text-xs text-gray-400'>
-          <th className='pl-4 py-2 font-normal text-left'>Price({pair.quoteSymbol})</th>
-          <th className='pl-4 py-2 font-normal text-right'>Amount({pair.baseSymbol})</th>
-          <th className='pl-4 py-2 font-normal text-right'>Total</th>
-          <th className='pl-4 py-2 font-normal text-right'>Route</th>
+          <th className='pl-4 py-2 font-normal text-left w-[1%] whitespace-nowrap'>
+            Price({pair.quoteSymbol})
+          </th>
+          <th className='py-2 font-normal text-right w-[1%] whitespace-nowrap'>
+            Amount({pair.baseSymbol})
+          </th>
+          <th className='py-2 font-normal text-right w-[1%] whitespace-nowrap'>Total</th>
+          <th className='py-2 font-normal text-right w-[1%] whitespace-nowrap'>Route</th>
         </tr>
       </thead>
 

--- a/src/pages/trade/ui/route-book.tsx
+++ b/src/pages/trade/ui/route-book.tsx
@@ -49,10 +49,10 @@ const RouteBookData = observer(({ bookData }: { bookData?: RouteBookResponse }) 
     <table className='w-full'>
       <thead>
         <tr className='text-xs text-gray-400'>
-          <th className='py-2 font-normal text-left'>Price({pair.quoteSymbol})</th>
-          <th className='py-2 font-normal text-right'>Amount({pair.baseSymbol})</th>
-          <th className='py-2 font-normal text-right'>Total</th>
-          <th className='py-2 font-normal text-right'>Route</th>
+          <th className='px-4 py-2 font-normal text-left'>Price({pair.quoteSymbol})</th>
+          <th className='px-4 py-2 font-normal text-right'>Amount({pair.baseSymbol})</th>
+          <th className='px-4 py-2 font-normal text-right'>Total</th>
+          <th className='px-4 py-2 font-normal text-right'>Route</th>
         </tr>
       </thead>
 

--- a/src/pages/trade/ui/route-tabs.tsx
+++ b/src/pages/trade/ui/route-tabs.tsx
@@ -15,7 +15,7 @@ export const RouteTabs = () => {
   const [tab, setTab] = useState<RouteTabsType>(RouteTabsType.Book);
 
   return (
-    <div ref={parent} className='flex flex-col gap-2 h-full'>
+    <div ref={parent} className='flex flex-col h-full'>
       <div className='flex justify-between gap-2 px-4 lg:pt-2 border-b border-b-other-solidStroke'>
         <Density medium>
           <Tabs

--- a/src/pages/trade/ui/route-tabs.tsx
+++ b/src/pages/trade/ui/route-tabs.tsx
@@ -15,7 +15,7 @@ export const RouteTabs = () => {
   const [tab, setTab] = useState<RouteTabsType>(RouteTabsType.Book);
 
   return (
-    <div ref={parent} className='flex flex-col gap-2 h-full overflow-hidden'>
+    <div ref={parent} className='flex flex-col gap-2 h-full'>
       <div className='flex justify-between gap-2 px-4 lg:pt-2 border-b border-b-other-solidStroke'>
         <Density medium>
           <Tabs

--- a/src/pages/trade/ui/trade-row.tsx
+++ b/src/pages/trade/ui/trade-row.tsx
@@ -2,6 +2,7 @@ import { Trace } from '@/shared/api/server/book/types.ts';
 import { getSymbolFromValueView } from '@penumbra-zone/getters/value-view';
 import React from 'react';
 import { ChevronRight } from 'lucide-react';
+import { Text } from '@penumbra-zone/ui/Text';
 
 function formatPrice(price: string): string {
   const num = parseFloat(price);
@@ -34,28 +35,27 @@ export const TradeRow = ({
   const bgColor = isSell ? SELL_BG_COLOR : 'rgba(28, 121, 63, 0.24)';
 
   return (
-    <tr
-      className='h-[33px] border-b border-border-faded group text-[12px]'
+    <div
+      className='px-4 group relative h-[33px] border-b border-border-faded text-xs grid grid-cols-[1fr_1fr_1fr_1fr] items-center'
       style={{
         backgroundImage: `linear-gradient(to right, ${bgColor} ${relativeSize}%, transparent ${relativeSize}%)`,
       }}
     >
-      <td className={`${isSell ? 'text-red-400' : 'text-green-400'} px-4`}>
+      <div className={`${isSell ? 'text-red-400' : 'text-green-400'}`}>
         {formatPrice(trace.price)}
-      </td>
-      <td className='text-right text-white '>{formatNumber(trace.amount)}</td>
-      <td className='text-right text-white'>{formatNumber(trace.total)}</td>
-      <td className='text-right'>
+      </div>
+      <div className='text-right text-white'>{formatNumber(trace.amount)}</div>
+      <div className='text-right text-white'>{formatNumber(trace.total)}</div>
+      <div className='text-right'>
         <HopCount count={trace.hops.length} />
-      </td>
+      </div>
 
-      {/* Overlay row that appears on hover */}
-      {/* eslint-disable-next-line react/no-unknown-property -- JSX style is valid in nextjs */}
+      {/* Overlay that appears on hover */}
       <style jsx>{`
-        tr:hover td {
+        .group:hover > div:not(:last-child) {
           visibility: hidden;
         }
-        tr:hover::after {
+        .group:hover::after {
           content: '';
           position: absolute;
           left: 0;
@@ -66,14 +66,13 @@ export const TradeRow = ({
       `}</style>
 
       {/* Route display that shows on hover */}
-      <td
+      <div
         className='hidden group-hover:flex justify-center absolute left-0 right-0 px-4 select-none z-30'
-        colSpan={4}
         style={{ visibility: 'visible' }}
       >
         <RouteDisplay tokens={trace.hops.map(valueView => getSymbolFromValueView(valueView))} />
-      </td>
-    </tr>
+      </div>
+    </div>
   );
 };
 

--- a/src/pages/trade/ui/trade-row.tsx
+++ b/src/pages/trade/ui/trade-row.tsx
@@ -3,11 +3,22 @@ import { getSymbolFromValueView } from '@penumbra-zone/getters/value-view';
 import React from 'react';
 import { ChevronRight } from 'lucide-react';
 
-function padPrice(price: string): string {
-  const [whole, decimal = ''] = price.split('.');
-  const maxDigits = 8; // Maximum decimals commonly used for crypto prices
-  const paddedDecimal = decimal.padEnd(maxDigits, '0');
-  return `${whole}.${paddedDecimal}`;
+function formatPrice(price: string): string {
+  const num = parseFloat(price);
+  const parts = num.toString().split('.');
+  const whole = parts[0] ?? '0';
+  const totalDigits = 7;
+  const availableDecimals = Math.max(0, totalDigits - whole.length);
+  return num.toFixed(availableDecimals);
+}
+
+function formatNumber(value: string): string {
+  const num = parseFloat(value);
+  const parts = num.toString().split('.');
+  const whole = parts[0] ?? '0';
+  const totalDigits = 6;
+  const availableDecimals = Math.max(0, totalDigits - whole.length);
+  return num.toFixed(availableDecimals);
 }
 
 const SELL_BG_COLOR = 'rgba(175, 38, 38, 0.24)';
@@ -21,7 +32,6 @@ export const TradeRow = ({
   relativeSize: number;
 }) => {
   const bgColor = isSell ? SELL_BG_COLOR : 'rgba(28, 121, 63, 0.24)';
-  const paddedPrice = padPrice(trace.price);
 
   return (
     <tr
@@ -31,10 +41,10 @@ export const TradeRow = ({
       }}
     >
       <td className={`${isSell ? 'text-red-400' : 'text-green-400'} px-4 text-xs`}>
-        {paddedPrice}
+        {formatPrice(trace.price)}
       </td>
-      <td className='text-xs px-4 text-right text-white'>{trace.amount}</td>
-      <td className='text-xs px-4 text-right text-white'>{trace.total}</td>
+      <td className='text-xs px-4 text-right text-white'>{formatNumber(trace.amount)}</td>
+      <td className='text-xs px-4 text-right text-white'>{formatNumber(trace.total)}</td>
       <td className='text-xs px-4 text-right'>
         <HopCount count={trace.hops.length} />
       </td>

--- a/src/pages/trade/ui/trade-row.tsx
+++ b/src/pages/trade/ui/trade-row.tsx
@@ -2,7 +2,6 @@ import { Trace } from '@/shared/api/server/book/types.ts';
 import { getSymbolFromValueView } from '@penumbra-zone/getters/value-view';
 import React from 'react';
 import { ChevronRight } from 'lucide-react';
-import { Text } from '@penumbra-zone/ui/Text';
 
 function formatPrice(price: string): string {
   const num = parseFloat(price);
@@ -41,9 +40,7 @@ export const TradeRow = ({
         backgroundImage: `linear-gradient(to right, ${bgColor} ${relativeSize}%, transparent ${relativeSize}%)`,
       }}
     >
-      <div className={`${isSell ? 'text-red-400' : 'text-green-400'}`}>
-        {formatPrice(trace.price)}
-      </div>
+      <div className={isSell ? 'text-red-400' : 'text-green-400'}>{formatPrice(trace.price)}</div>
       <div className='text-right text-white'>{formatNumber(trace.amount)}</div>
       <div className='text-right text-white'>{formatNumber(trace.total)}</div>
       <div className='text-right'>
@@ -51,6 +48,7 @@ export const TradeRow = ({
       </div>
 
       {/* Overlay that appears on hover */}
+      {/* eslint-disable-next-line react/no-unknown-property -- jsx is, in fact, a property */}
       <style jsx>{`
         .group:hover > div:not(:last-child) {
           visibility: hidden;

--- a/src/pages/trade/ui/trade-row.tsx
+++ b/src/pages/trade/ui/trade-row.tsx
@@ -35,17 +35,17 @@ export const TradeRow = ({
 
   return (
     <tr
-      className='h-[33px] border-b border-border-faded group'
+      className='h-[33px] border-b border-border-faded group text-[12px]'
       style={{
         backgroundImage: `linear-gradient(to right, ${bgColor} ${relativeSize}%, transparent ${relativeSize}%)`,
       }}
     >
-      <td className={`${isSell ? 'text-red-400' : 'text-green-400'} px-4 text-xs`}>
+      <td className={`${isSell ? 'text-red-400' : 'text-green-400'} px-4`}>
         {formatPrice(trace.price)}
       </td>
-      <td className='text-xs px-4 text-right text-white'>{formatNumber(trace.amount)}</td>
-      <td className='text-xs px-4 text-right text-white'>{formatNumber(trace.total)}</td>
-      <td className='text-xs px-4 text-right'>
+      <td className='text-right text-white '>{formatNumber(trace.amount)}</td>
+      <td className='text-right text-white'>{formatNumber(trace.total)}</td>
+      <td className='text-right'>
         <HopCount count={trace.hops.length} />
       </td>
 

--- a/src/pages/trade/ui/trade-row.tsx
+++ b/src/pages/trade/ui/trade-row.tsx
@@ -30,10 +30,12 @@ export const TradeRow = ({
         backgroundImage: `linear-gradient(to right, ${bgColor} ${relativeSize}%, transparent ${relativeSize}%)`,
       }}
     >
-      <td className={`${isSell ? 'text-red-400' : 'text-green-400'} text-xs`}>{paddedPrice}</td>
-      <td className='text-xs text-right text-white'>{trace.amount}</td>
-      <td className='text-xs text-right text-white'>{trace.total}</td>
-      <td className='text-xs text-right'>
+      <td className={`${isSell ? 'text-red-400' : 'text-green-400'} px-4 text-xs`}>
+        {paddedPrice}
+      </td>
+      <td className='text-xs px-4 text-right text-white'>{trace.amount}</td>
+      <td className='text-xs px-4 text-right text-white'>{trace.total}</td>
+      <td className='text-xs px-4 text-right'>
         <HopCount count={trace.hops.length} />
       </td>
 


### PR DESCRIPTION
fixes #146 
- Adjusted padding in routebook
- Replace custom skeleton with the reusable skeleton
- Adjusted formatting of numbers to conform with Figma and fit on smaller screens, including the padding.