### PR TITLE
fix: serialize dates too

### DIFF
--- a/src/shared/utils/serializer.ts
+++ b/src/shared/utils/serializer.ts
@@ -26,6 +26,10 @@ export const serialize = <VAL>(value: VAL): Serialized<VAL> => {
     return value.map(v => serialize(v) as Serialized<unknown>) as Serialized<VAL>;
   }
 
+  if (value instanceof Date) {
+    return value.toString() as Serialized<VAL>;
+  }
+
   if (isMessage(value)) {
     return {
       proto: value.getType().typeName,


### PR DESCRIPTION
Recently the pindexer started saving/returning dates as date-objects, not as strings, therefore breaking the serialization. This fix restores the explore page affected by the change