### PR TITLE
Lp inspect: move registry info to frontend

### DIFF
--- a/src/pages/inspect/lp/api/position.ts
+++ b/src/pages/inspect/lp/api/position.ts
@@ -1,12 +1,117 @@
 import { useQuery } from '@tanstack/react-query';
-import { PositionTimelineResponse } from '@/shared/api/server/position/timeline/types';
+import {
+  PositionExecutions,
+  PositionStateResponse,
+  PositionTimelineResponse,
+  PositionWithdrawal,
+  VolumeAndFeesResponse,
+} from '@/shared/api/server/position/timeline/types';
 import { apiFetch } from '@/shared/utils/api-fetch.ts';
+import {
+  PositionExecutionsVV,
+  PositionStateVV,
+  PositionTimelineResponseVV,
+  PositionWithdrawalVV,
+  VolumeAndFeesAll,
+} from '@/pages/inspect/lp/api/types.ts';
+import { Registry } from '@penumbra-labs/registry';
+import { registryQueryFn } from '@/shared/api/registry.ts';
+import { getValueView } from '@/shared/api/server/book/helpers.ts';
+
+const positionsStateAddVV = (res: PositionStateResponse, registry: Registry): PositionStateVV => {
+  return {
+    reserves1: getValueView(registry, res.reserves1),
+    reserves2: getValueView(registry, res.reserves2),
+    unit1: getValueView(registry, res.unit1),
+    unit2: getValueView(registry, res.unit2),
+    offer1: getValueView(registry, res.offer1),
+    offer2: getValueView(registry, res.offer2),
+    priceRef1: getValueView(registry, res.priceRef1),
+    priceRef2: getValueView(registry, res.priceRef2),
+    priceRef1Inv: getValueView(registry, res.priceRef1Inv),
+    priceRef2Inv: getValueView(registry, res.priceRef2Inv),
+    feeBps: res.feeBps,
+    openingHeight: res.openingHeight,
+    openingTime: res.openingTime,
+    openingTx: res.openingTx,
+    closingHeight: res.closingHeight,
+    closingTime: res.closingTime,
+    closingTx: res.closingTx,
+  };
+};
+
+const executionsAddVV = (res: PositionExecutions, registry: Registry): PositionExecutionsVV => {
+  return {
+    items: res.items.map(p => ({
+      input: getValueView(registry, p.input),
+      output: getValueView(registry, p.output),
+      fee: getValueView(registry, p.fee),
+      reserves1: getValueView(registry, p.reserves1),
+      reserves2: getValueView(registry, p.reserves2),
+      contextStart: registry.getMetadata(p.contextStart),
+      contextEnd: registry.getMetadata(p.contextEnd),
+      time: p.time,
+      height: p.height,
+    })),
+    skipped: res.skipped,
+  };
+};
+
+const withdrawalsAddVV = (
+  res: PositionWithdrawal[],
+  registry: Registry,
+): PositionWithdrawalVV[] => {
+  return res.map(w => ({
+    reserves1: getValueView(registry, w.reserves1),
+    reserves2: getValueView(registry, w.reserves2),
+    time: w.time,
+    height: w.height,
+    txHash: w.txHash,
+  }));
+};
+
+const volumeAddVV = (res: VolumeAndFeesResponse, registry: Registry): VolumeAndFeesAll => {
+  return {
+    asset1: registry.getMetadata(res.asset1),
+    asset2: registry.getMetadata(res.asset2),
+    totals: {
+      volume1: getValueView(registry, res.totals.volume1),
+      volume2: getValueView(registry, res.totals.volume2),
+      fees1: getValueView(registry, res.totals.fees1),
+      fees2: getValueView(registry, res.totals.fees2),
+      executionCount: res.totals.executionCount,
+    },
+    all: res.all.map(v => ({
+      volume1: getValueView(registry, v.volume1),
+      volume2: getValueView(registry, v.volume2),
+      fees1: getValueView(registry, v.fees1),
+      fees2: getValueView(registry, v.fees2),
+      contextAssetStart: registry.getMetadata(v.contextAssetStart),
+      contextAssetEnd: registry.getMetadata(v.contextAssetEnd),
+      executionCount: v.executionCount,
+    })),
+  };
+};
+
+const timelineFetch = async (id: string): Promise<PositionTimelineResponseVV> => {
+  const result = await apiFetch<PositionTimelineResponse>(
+    `/api/position/timeline?positionId=${id}`,
+  );
+
+  const registry = await registryQueryFn();
+
+  return {
+    state: positionsStateAddVV(result.state, registry),
+    executions: executionsAddVV(result.executions, registry),
+    withdrawals: withdrawalsAddVV(result.withdrawals, registry),
+    volumeAndFees: volumeAddVV(result.volumeAndFees, registry),
+  };
+};
 
 export const useLpPosition = (id: string) => {
   return useQuery({
     queryKey: ['lpPosition', id],
     retry: 1,
-    queryFn: async () =>
-      apiFetch<PositionTimelineResponse>(`/api/position/timeline?positionId=${id}`),
+    queryFn: () => timelineFetch(id),
   });
 };

--- a/src/pages/inspect/lp/api/types.ts
+++ b/src/pages/inspect/lp/api/types.ts
@@ -1,0 +1,70 @@
+import { Metadata, ValueView } from '@penumbra-zone/protobuf/penumbra/core/asset/v1/asset_pb';
+
+export interface PositionStateVV {
+  reserves1: ValueView;
+  reserves2: ValueView;
+  unit1: ValueView;
+  unit2: ValueView;
+  offer1: ValueView;
+  offer2: ValueView;
+  priceRef1: ValueView;
+  priceRef2: ValueView;
+  priceRef1Inv: ValueView;
+  priceRef2Inv: ValueView;
+  feeBps: number;
+  openingHeight: number;
+  openingTime: string;
+  openingTx?: string;
+  closingHeight?: number;
+  closingTime?: string;
+  closingTx?: string;
+}
+
+export interface VolumeAndFeesVV {
+  volume1: ValueView;
+  volume2: ValueView;
+  fees1: ValueView;
+  fees2: ValueView;
+  contextAssetStart: Metadata;
+  contextAssetEnd: Metadata;
+  executionCount: number;
+}
+
+export interface VolumeAndFeesAll {
+  asset1: Metadata;
+  asset2: Metadata;
+  totals: Omit<VolumeAndFeesVV, 'contextAssetStart' | 'contextAssetEnd'>;
+  all: VolumeAndFeesVV[];
+}
+
+export interface PositionWithdrawalVV {
+  reserves1: ValueView;
+  reserves2: ValueView;
+  time: string;
+  height: number;
+  txHash: string;
+}
+
+export interface PositionExecutionVV {
+  input: ValueView;
+  output: ValueView;
+  fee: ValueView;
+  reserves1: ValueView;
+  reserves2: ValueView;
+  contextStart: Metadata;
+  contextEnd: Metadata;
+  time: string;
+  height: number;
+}
+
+export interface PositionExecutionsVV {
+  items: PositionExecutionVV[];
+  skipped: number;
+}
+
+export interface PositionTimelineResponseVV {
+  executions: PositionExecutionsVV;
+  state: PositionStateVV;
+  withdrawals: PositionWithdrawalVV[];
+  volumeAndFees: VolumeAndFeesAll;
+}

--- a/src/pages/inspect/ui/actions.tsx
+++ b/src/pages/inspect/ui/actions.tsx
@@ -1,14 +1,11 @@
 import { Text } from '@penumbra-zone/ui/Text';
-import {
-  PositionStateResponse,
-  PositionWithdrawal,
-} from '@/shared/api/server/position/timeline/types.ts';
 import { Card } from '@penumbra-zone/ui/Card';
 import { ValueViewComponent } from '@penumbra-zone/ui/ValueView';
 import { TimeDisplay } from '@/pages/inspect/ui/time.tsx';
 import { useLpIdInUrl } from '@/pages/inspect/ui/result.tsx';
 import { useLpPosition } from '@/pages/inspect/lp/api/position.ts';
 import { Skeleton } from '@/shared/ui/skeleton.tsx';
+import { PositionStateVV, PositionWithdrawalVV } from '@/pages/inspect/lp/api/types.ts';
 
 export const PositionClosed = ({
   closingTx,
@@ -43,7 +40,7 @@ export const PositionClosed = ({
   );
 };
 
-export const PositionWithdraw = ({ withdrawal }: { withdrawal: PositionWithdrawal }) => {
+export const PositionWithdraw = ({ withdrawal }: { withdrawal: PositionWithdrawalVV }) => {
   return (
     <div className='grid grid-cols-6 items-center mb-4'>
       <div className='col-span-4'>
@@ -69,7 +66,7 @@ export const PositionWithdraw = ({ withdrawal }: { withdrawal: PositionWithdrawa
   );
 };
 
-export const PositionOpen = ({ state }: { state: PositionStateResponse }) => {
+export const PositionOpen = ({ state }: { state: PositionStateVV }) => {
   return (
     <div className='grid grid-cols-6 items-center mb-4'>
       <div className='col-span-4'>
@@ -99,8 +96,8 @@ const DataBody = ({
   state,
   withdrawals,
 }: {
-  state: PositionStateResponse;
-  withdrawals: PositionWithdrawal[];
+  state: PositionStateVV;
+  withdrawals: PositionWithdrawalVV[];
 }) => {
   return (
     <div className='flex flex-col gap-4 justify-center'>

--- a/src/pages/inspect/ui/executions.tsx
+++ b/src/pages/inspect/ui/executions.tsx
@@ -9,18 +9,15 @@ import { TimeDisplay } from '@/pages/inspect/ui/time.tsx';
 import { useLpIdInUrl } from '@/pages/inspect/ui/result.tsx';
 import { useLpPosition } from '@/pages/inspect/lp/api/position.ts';
 import { Skeleton } from '@/shared/ui/skeleton.tsx';
+import { PositionClosed, PositionOpen, PositionWithdraw } from '@/pages/inspect/ui/actions.tsx';
 import {
-  PositionExecutions,
-  PositionStateResponse,
-  PositionWithdrawal,
-} from '@/shared/api/server/position/timeline/types.ts';
-import { PositionWithdraw, PositionClosed, PositionOpen } from '@/pages/inspect/ui/actions.tsx';
+  PositionExecutionsVV,
+  PositionExecutionVV,
+  PositionStateVV,
+  PositionWithdrawalVV,
+} from '@/pages/inspect/lp/api/types.ts';
 
-interface ExecutionProps {
-  execution: PositionExecutions['items'][0];
-}
-
-const Execution = ({ execution: e }: ExecutionProps) => {
+const Execution = ({ execution: e }: { execution: PositionExecutionVV }) => {
   return (
     <div className='grid grid-cols-6 items-center mb-4'>
       <div className='col-span-2'>
@@ -93,9 +90,9 @@ const DataBody = ({
   withdrawals,
   executions,
 }: {
-  state: PositionStateResponse;
-  withdrawals: PositionWithdrawal[];
-  executions: PositionExecutions;
+  state: PositionStateVV;
+  withdrawals: PositionWithdrawalVV[];
+  executions: PositionExecutionsVV;
 }) => {
   return (
     <div>

--- a/src/pages/inspect/ui/state-details.tsx
+++ b/src/pages/inspect/ui/state-details.tsx
@@ -5,10 +5,10 @@ import { Icon } from '@penumbra-zone/ui/Icon';
 import { Density } from '@penumbra-zone/ui/Density';
 import { useLpPosition } from '@/pages/inspect/lp/api/position.ts';
 import { useLpIdInUrl } from '@/pages/inspect/ui/result.tsx';
-import { PositionStateResponse } from '@/shared/api/server/position/timeline/types.ts';
 import { Skeleton } from '@/shared/ui/skeleton.tsx';
+import { PositionStateVV } from '@/pages/inspect/lp/api/types.ts';
 
-const DataBody = ({ state }: { state: PositionStateResponse }) => {
+const DataBody = ({ state }: { state: PositionStateVV }) => {
   return (
     <>
       <div className='flex items-start justify-between gap-2'>

--- a/src/pages/inspect/ui/volume.tsx
+++ b/src/pages/inspect/ui/volume.tsx
@@ -7,9 +7,9 @@ import { Table } from '@penumbra-zone/ui/Table';
 import { AssetIcon } from '@penumbra-zone/ui/AssetIcon';
 import { useLpIdInUrl } from '@/pages/inspect/ui/result.tsx';
 import { useLpPosition } from '@/pages/inspect/lp/api/position.ts';
-import { VolumeAndFeesResponse } from '@/shared/api/server/position/timeline/types.ts';
 import { Skeleton } from '@/shared/ui/skeleton';
 import { Card } from '@penumbra-zone/ui/Card';
+import { VolumeAndFeesAll } from '@/pages/inspect/lp/api/types.ts';
 
 const skeletonRows = 4;
 
@@ -52,7 +52,7 @@ const LoadingState = () => {
   );
 };
 
-const DataBody = ({ v }: { v: VolumeAndFeesResponse }) => {
+const DataBody = ({ v }: { v: VolumeAndFeesAll }) => {
   return (
     <Density compact>
       <Table>
@@ -116,9 +116,15 @@ const DataBody = ({ v }: { v: VolumeAndFeesResponse }) => {
               <Table.Tr key={i}>
                 <Table.Td>
                   <div className='flex items-center gap-2'>
-                    <AssetIcon metadata={row.contextAssetStart} />
+                    <div className='flex gap-1'>
+                      <AssetIcon metadata={row.contextAssetStart} />
+                      {row.contextAssetStart.symbol}
+                    </div>
                     <Icon IconComponent={ArrowRight} color='text.primary' size='sm' />
-                    <AssetIcon metadata={row.contextAssetEnd} />
+                    <div className='flex gap-1'>
+                      <AssetIcon metadata={row.contextAssetEnd} />
+                      {row.contextAssetEnd.symbol}
+                    </div>
                   </div>
                 </Table.Td>
                 <Table.Td hAlign='center'>

--- a/src/pages/trade/ui/positions.tsx
+++ b/src/pages/trade/ui/positions.tsx
@@ -15,6 +15,8 @@ import {
 import { bech32mPositionId } from '@penumbra-zone/bech32m/plpid';
 import { Button } from '@penumbra-zone/ui/Button';
 import { positionsStore } from '@/pages/trade/model/positions';
+import Link from 'next/link';
+import { SquareArrowOutUpRight } from 'lucide-react';
 
 const LoadingRow = () => {
   return (
@@ -260,6 +262,9 @@ const PositionsInner = observer(({ showInactive }: { showInactive: boolean }) =>
                   <Text detail color='text.secondary' truncate>
                     {bech32PositionId}
                   </Text>
+                  <Link href={`/inspect/lp/${bech32PositionId}`}>
+                    <SquareArrowOutUpRight className='w-4 h-4 text-text-secondary' />
+                  </Link>
                 </Cell>
                 <Cell>
                   <ActionButton state={p.positionState} id={p.positionId} />

--- a/src/shared/api/server/position/timeline/executions.ts
+++ b/src/shared/api/server/position/timeline/executions.ts
@@ -1,92 +1,63 @@
-import { ChainRegistryClient, Registry } from '@penumbra-labs/registry';
 import { AssetId, Value } from '@penumbra-zone/protobuf/penumbra/core/asset/v1/asset_pb';
-import { getValueView } from '../../book/helpers';
 import { pnum } from '@penumbra-zone/types/pnum';
 import {
   PositionExecution,
   PositionExecutions,
   PositionStateResponse,
 } from '@/shared/api/server/position/timeline/types.ts';
-import { getAssetIdFromValueView } from '@penumbra-zone/getters/value-view';
-import { ExecutionWithReserves } from '@/shared/database';
+import { ExecutionWithReserves, pindexer } from '@/shared/database';
+import { PositionId } from '@penumbra-zone/protobuf/penumbra/core/component/dex/v1/dex_pb';
+import { getAssetIdFromValue } from '@penumbra-zone/getters/value';
 
-const addValueView = (
-  registry: Registry,
+const addValue = (
   raw: ExecutionWithReserves,
   assetId1: AssetId,
   assetId2: AssetId,
 ): PositionExecution => {
   const isAsset1Input = BigInt(raw.execution.delta_1) !== 0n; // Determine trade direction
   const input = isAsset1Input
-    ? getValueView(
-        registry,
-        new Value({
-          amount: pnum(raw.execution.delta_1).toAmount(),
-          assetId: assetId1,
-        }),
-      )
-    : getValueView(
-        registry,
-        new Value({
-          amount: pnum(raw.execution.delta_2).toAmount(),
-          assetId: assetId2,
-        }),
-      );
+    ? new Value({
+        amount: pnum(raw.execution.delta_1).toAmount(),
+        assetId: assetId1,
+      })
+    : new Value({
+        amount: pnum(raw.execution.delta_2).toAmount(),
+        assetId: assetId2,
+      });
 
   const output = isAsset1Input
-    ? getValueView(
-        registry,
-        new Value({
-          amount: pnum(raw.execution.delta_2).toAmount(),
-          assetId: assetId2,
-        }),
-      )
-    : getValueView(
-        registry,
-        new Value({
-          amount: pnum(raw.execution.delta_1).toAmount(),
-          assetId: assetId1,
-        }),
-      );
+    ? new Value({
+        amount: pnum(raw.execution.delta_2).toAmount(),
+        assetId: assetId2,
+      })
+    : new Value({
+        amount: pnum(raw.execution.delta_1).toAmount(),
+        assetId: assetId1,
+      });
 
   const fee = isAsset1Input
-    ? getValueView(
-        registry,
-        new Value({
-          amount: pnum(raw.execution.fee_1).toAmount(),
-          assetId: assetId1,
-        }),
-      )
-    : getValueView(
-        registry,
-        new Value({
-          amount: pnum(raw.execution.fee_2).toAmount(),
-          assetId: assetId2,
-        }),
-      );
+    ? new Value({
+        amount: pnum(raw.execution.fee_1).toAmount(),
+        assetId: assetId1,
+      })
+    : new Value({
+        amount: pnum(raw.execution.fee_2).toAmount(),
+        assetId: assetId2,
+      });
 
-  const reserves1 = getValueView(
-    registry,
-    new Value({
-      amount: pnum(raw.reserves.reserves_1).toAmount(),
-      assetId: assetId1,
-    }),
-  );
+  const reserves1 = new Value({
+    amount: pnum(raw.reserves.reserves_1).toAmount(),
+    assetId: assetId1,
+  });
 
-  const reserves2 = getValueView(
-    registry,
-    new Value({
-      amount: pnum(raw.reserves.reserves_2).toAmount(),
-      assetId: assetId2,
-    }),
-  );
-
-  const assetIdCxtStart = new AssetId({
+  const reserves2 = new Value({
+    amount: pnum(raw.reserves.reserves_2).toAmount(),
+    assetId: assetId2,
+  });
+  const contextStart = new AssetId({
     inner: Uint8Array.from(raw.execution.context_asset_start),
   });
-  const assetIdCxtEnd = new AssetId({ inner: Uint8Array.from(raw.execution.context_asset_end) });
-  const contextStart = registry.getMetadata(assetIdCxtStart);
-  const contextEnd = registry.getMetadata(assetIdCxtEnd);
+  const contextEnd = new AssetId({ inner: Uint8Array.from(raw.execution.context_asset_end) });
 
   const time = raw.execution.time.toISOString();
   const height = raw.execution.height;
@@ -104,22 +75,17 @@ const addValueView = (
   };
 };
 
-export const addValueViewsToExecutions = async (
+export const getExecutions = async (
+  id: PositionId,
   state: PositionStateResponse,
-  raw: { items: ExecutionWithReserves[]; skippedRows: number },
 ): Promise<PositionExecutions> => {
-  const chainId = process.env['PENUMBRA_CHAIN_ID'];
-  if (!chainId) {
-    throw new Error('PENUMBRA_CHAIN_ID is not set');
-  }
-  const registryClient = new ChainRegistryClient();
-  const registry = await registryClient.remote.get(chainId);
+  const result = await pindexer.getPositionExecutionsWithReserves(id);
 
-  const asset1Id = getAssetIdFromValueView(state.reserves1);
-  const asset2Id = getAssetIdFromValueView(state.reserves2);
+  const asset1Id = getAssetIdFromValue(state.reserves1);
+  const asset2Id = getAssetIdFromValue(state.reserves2);
 
   return {
-    skipped: raw.skippedRows,
-    items: raw.items.map(i => addValueView(registry, i, asset1Id, asset2Id)),
+    skipped: result.skippedRows,
+    items: result.items.map(i => addValue(i, asset1Id, asset2Id)),
   };
 };

--- a/src/shared/api/server/position/timeline/index.ts
+++ b/src/shared/api/server/position/timeline/index.ts
@@ -1,13 +1,12 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { pindexer } from '@/shared/database';
 import { PositionTimelineResponse, TimelineApiResponse } from './types';
 import { positionIdFromBech32 } from '@penumbra-zone/bech32m/plpid';
 import { PositionId } from '@penumbra-zone/protobuf/penumbra/core/component/dex/v1/dex_pb';
 import { serialize } from '@/shared/utils/serializer.ts';
 import { getPositionState } from '@/shared/api/server/position/timeline/state.ts';
-import { addValueViewsToVolume } from '@/shared/api/server/position/timeline/volume.ts';
+import { addValueToVolume } from '@/shared/api/server/position/timeline/volume.ts';
 import { addValueViewsToWithdrawals } from '@/shared/api/server/position/timeline/withdraws.ts';
-import { addValueViewsToExecutions } from '@/shared/api/server/position/timeline/executions.ts';
+import { getExecutions } from '@/shared/api/server/position/timeline/executions.ts';
 
 export async function GET(req: NextRequest): Promise<NextResponse<TimelineApiResponse>> {
   try {
@@ -20,17 +19,12 @@ export async function GET(req: NextRequest): Promise<NextResponse<TimelineApiRes
 
     const id = new PositionId(positionIdFromBech32(positionIdStr));
 
-    const [state, executionsRaw, withdrawalsRaw, volumeAndFeesRaw] = await Promise.all([
-      getPositionState(id),
-      pindexer.getPositionExecutionsWithReserves(id),
-      pindexer.getPositionWithdrawals(id),
-      pindexer.getPositionVolumeAndFees(id),
-    ]);
+    const state = await getPositionState(id);
 
     const [executions, withdrawals, volumeAndFees] = await Promise.all([
-      addValueViewsToExecutions(state, executionsRaw),
-      addValueViewsToWithdrawals(state, withdrawalsRaw),
-      addValueViewsToVolume(state, volumeAndFeesRaw),
+      getExecutions(id, state),
+      addValueViewsToWithdrawals(id, state),
+      addValueToVolume(id, state),
     ]);
 
     const response = serialize({

--- a/src/shared/api/server/position/timeline/state.ts
+++ b/src/shared/api/server/position/timeline/state.ts
@@ -2,7 +2,6 @@ import { pindexer } from '@/shared/database';
 import { ChainRegistryClient } from '@penumbra-labs/registry';
 import { AssetId, Value } from '@penumbra-zone/protobuf/penumbra/core/asset/v1/asset_pb';
 import { PositionId } from '@penumbra-zone/protobuf/penumbra/core/component/dex/v1/dex_pb';
-import { getValueView } from '../../book/helpers';
 import { pnum } from '@penumbra-zone/types/pnum';
 import { PositionStateResponse } from '@/shared/api/server/position/timeline/types.ts';
 import { sha256HashStr } from '@penumbra-zone/crypto-web/sha256';
@@ -44,76 +43,46 @@ export const getPositionState = async (id: PositionId): Promise<PositionStateRes
 
   const response: PositionStateResponse = {
     feeBps: result.state.fee_bps,
-    reserves1: getValueView(
-      registry,
-      new Value({
-        assetId: assetId1,
-        amount: pnum(result.latestReserves.reserves_1).toAmount(),
-      }),
-    ),
-    reserves2: getValueView(
-      registry,
-      new Value({
-        assetId: assetId2,
-        amount: pnum(result.latestReserves.reserves_2).toAmount(),
-      }),
-    ),
-    unit1: getValueView(
-      registry,
-      new Value({
-        assetId: assetId1,
-        amount: pnum(unit1Amount).toAmount(),
-      }),
-    ),
-    unit2: getValueView(
-      registry,
-      new Value({
-        assetId: assetId2,
-        amount: pnum(unit2Amount).toAmount(),
-      }),
-    ),
-    offer1: getValueView(
-      registry,
-      new Value({
-        assetId: assetId1,
-        amount: pnum(offer1Amount).toAmount(),
-      }),
-    ),
-    offer2: getValueView(
-      registry,
-      new Value({
-        assetId: assetId2,
-        amount: pnum(offer2Amount).toAmount(),
-      }),
-    ),
-    priceRef1: getValueView(
-      registry,
-      new Value({
-        assetId: assetId1,
-        amount: pnum(priceRef1Amount).toAmount(),
-      }),
-    ),
-    priceRef2: getValueView(
-      registry,
-      new Value({
-        assetId: assetId2,
-        amount: pnum(priceRef2Amount).toAmount(),
-      }),
-    ),
-    priceRef1Inv: getValueView(
-      registry,
-      new Value({
-        assetId: assetId2,
-        amount: pnum(priceRef1AmountInv).toAmount(),
-      }),
-    ),
-    priceRef2Inv: getValueView(
-      registry,
-      new Value({
-        assetId: assetId1,
-        amount: pnum(priceRef2AmountInv).toAmount(),
-      }),
-    ),
+    reserves1: new Value({
+      assetId: assetId1,
+      amount: pnum(result.latestReserves.reserves_1).toAmount(),
+    }),
+    reserves2: new Value({
+      assetId: assetId2,
+      amount: pnum(result.latestReserves.reserves_2).toAmount(),
+    }),
+    unit1: new Value({
+      assetId: assetId1,
+      amount: pnum(unit1Amount).toAmount(),
+    }),
+    unit2: new Value({
+      assetId: assetId2,
+      amount: pnum(unit2Amount).toAmount(),
+    }),
+    offer1: new Value({
+      assetId: assetId1,
+      amount: pnum(offer1Amount).toAmount(),
+    }),
+    offer2: new Value({
+      assetId: assetId2,
+      amount: pnum(offer2Amount).toAmount(),
+    }),
+    priceRef1: new Value({
+      assetId: assetId1,
+      amount: pnum(priceRef1Amount).toAmount(),
+    }),
+    priceRef2: new Value({
+      assetId: assetId2,
+      amount: pnum(priceRef2Amount).toAmount(),
+    }),
+    priceRef1Inv: new Value({
+      assetId: assetId2,
+      amount: pnum(priceRef1AmountInv).toAmount(),
+    }),
+    priceRef2Inv: new Value({
+      assetId: assetId1,
+      amount: pnum(priceRef2AmountInv).toAmount(),
+    }),
     openingHeight: result.state.opening_height,
     openingTime: result.state.opening_time.toISOString(),
   };

--- a/src/shared/api/server/position/timeline/types.ts
+++ b/src/shared/api/server/position/timeline/types.ts
@@ -1,17 +1,17 @@
 import { Serialized } from '@/shared/utils/serializer.ts';
-import { Metadata, ValueView } from '@penumbra-zone/protobuf/penumbra/core/asset/v1/asset_pb';
+import { AssetId, Value } from '@penumbra-zone/protobuf/penumbra/core/asset/v1/asset_pb';
 
 export interface PositionStateResponse {
-  reserves1: ValueView;
-  reserves2: ValueView;
-  unit1: ValueView;
-  unit2: ValueView;
-  offer1: ValueView;
-  offer2: ValueView;
-  priceRef1: ValueView;
-  priceRef2: ValueView;
-  priceRef1Inv: ValueView;
-  priceRef2Inv: ValueView;
+  reserves1: Value;
+  reserves2: Value;
+  unit1: Value;
+  unit2: Value;
+  offer1: Value;
+  offer2: Value;
+  priceRef1: Value;
+  priceRef2: Value;
+  priceRef1Inv: Value;
+  priceRef2Inv: Value;
   feeBps: number;
   openingHeight: number;
   openingTime: string;
@@ -21,39 +21,39 @@ export interface PositionStateResponse {
   closingTx?: string;
 }
 
-export interface VolumeAndFeesVV {
-  volume1: ValueView;
-  volume2: ValueView;
-  fees1: ValueView;
-  fees2: ValueView;
-  contextAssetStart: Metadata;
-  contextAssetEnd: Metadata;
+export interface VolumeAndFeesValue {
+  volume1: Value;
+  volume2: Value;
+  fees1: Value;
+  fees2: Value;
+  contextAssetStart: AssetId;
+  contextAssetEnd: AssetId;
   executionCount: number;
 }
 
 export interface VolumeAndFeesResponse {
-  asset1: Metadata;
-  asset2: Metadata;
-  totals: Omit<VolumeAndFeesVV, 'contextAssetStart' | 'contextAssetEnd'>;
-  all: VolumeAndFeesVV[];
+  asset1: AssetId;
+  asset2: AssetId;
+  totals: Omit<VolumeAndFeesValue, 'contextAssetStart' | 'contextAssetEnd'>;
+  all: VolumeAndFeesValue[];
 }
 
 export interface PositionWithdrawal {
-  reserves1: ValueView;
-  reserves2: ValueView;
+  reserves1: Value;
+  reserves2: Value;
   time: string;
   height: number;
   txHash: string;
 }
 
 export interface PositionExecution {
-  input: ValueView;
-  output: ValueView;
-  fee: ValueView;
-  reserves1: ValueView;
-  reserves2: ValueView;
-  contextStart: Metadata;
-  contextEnd: Metadata;
+  input: Value;
+  output: Value;
+  fee: Value;
+  reserves1: Value;
+  reserves2: Value;
+  contextStart: AssetId;
+  contextEnd: AssetId;
   time: string;
   height: number;
 }
@@ -64,8 +64,8 @@ export interface PositionExecutions {
 }
 
 export interface PositionTimelineResponse {
-  executions: PositionExecutions;
   state: PositionStateResponse;
+  executions: PositionExecutions;
   withdrawals: PositionWithdrawal[];
   volumeAndFees: VolumeAndFeesResponse;
 }

--- a/src/shared/api/server/position/timeline/withdraws.ts
+++ b/src/shared/api/server/position/timeline/withdraws.ts
@@ -1,6 +1,4 @@
-import { ChainRegistryClient, Registry } from '@penumbra-labs/registry';
 import { AssetId, Value } from '@penumbra-zone/protobuf/penumbra/core/asset/v1/asset_pb';
-import { getValueView } from '../../book/helpers';
 import { Selectable } from 'kysely';
 import { pnum } from '@penumbra-zone/types/pnum';
 import {
@@ -8,11 +6,12 @@ import {
   PositionWithdrawal,
 } from '@/shared/api/server/position/timeline/types.ts';
 import { DexExPositionWithdrawals } from '@/shared/database/schema.ts';
-import { getAssetIdFromValueView } from '@penumbra-zone/getters/value-view';
 import { sha256HashStr } from '@penumbra-zone/crypto-web/sha256';
+import { PositionId } from '@penumbra-zone/protobuf/penumbra/core/component/dex/v1/dex_pb';
+import { pindexer } from '@/shared/database';
+import { getAssetIdFromValue } from '@penumbra-zone/getters/value';
 
-const addValueView = async (
-  registry: Registry,
+const addValue = async (
   raw: Selectable<DexExPositionWithdrawals>,
   assetId1: AssetId,
   assetId2: AssetId,
@@ -21,36 +20,25 @@ const addValueView = async (
     txHash: raw.withdrawal_tx ? await sha256HashStr(raw.withdrawal_tx) : '',
     height: raw.height,
     time: raw.time.toISOString(),
-    reserves1: getValueView(
-      registry,
-      new Value({
-        amount: pnum(raw.reserves_1).toAmount(),
-        assetId: assetId1,
-      }),
-    ),
-    reserves2: getValueView(
-      registry,
-      new Value({
-        assetId: assetId2,
-        amount: pnum(raw.reserves_2).toAmount(),
-      }),
-    ),
+    reserves1: new Value({
+      amount: pnum(raw.reserves_1).toAmount(),
+      assetId: assetId1,
+    }),
+    reserves2: new Value({
+      assetId: assetId2,
+      amount: pnum(raw.reserves_2).toAmount(),
+    }),
   };
 };
 
 export const addValueViewsToWithdrawals = async (
+  id: PositionId,
   state: PositionStateResponse,
-  raw: Selectable<DexExPositionWithdrawals>[],
 ): Promise<PositionWithdrawal[]> => {
-  const chainId = process.env['PENUMBRA_CHAIN_ID'];
-  if (!chainId) {
-    throw new Error('PENUMBRA_CHAIN_ID is not set');
-  }
-  const registryClient = new ChainRegistryClient();
-  const registry = await registryClient.remote.get(chainId);
+  const result = await pindexer.getPositionWithdrawals(id);
 
-  const asset1Id = getAssetIdFromValueView(state.reserves1);
-  const asset2Id = getAssetIdFromValueView(state.reserves2);
+  const asset1Id = getAssetIdFromValue(state.reserves1);
+  const asset2Id = getAssetIdFromValue(state.reserves2);
 
-  return await Promise.all(raw.map(w => addValueView(registry, w, asset1Id, asset2Id)));
+  return await Promise.all(result.map(w => addValue(w, asset1Id, asset2Id)));
 };

--- a/src/shared/utils/serializer.ts
+++ b/src/shared/utils/serializer.ts
@@ -1,7 +1,12 @@
 /* eslint-disable @typescript-eslint/no-explicit-any -- Message<any> cannot be pre-determined */
 
 import { Message, isMessage, JsonValue } from '@bufbuild/protobuf';
-import { Metadata, ValueView } from '@penumbra-zone/protobuf/penumbra/core/asset/v1/asset_pb';
+import {
+  AssetId,
+  Metadata,
+  Value,
+  ValueView,
+} from '@penumbra-zone/protobuf/penumbra/core/asset/v1/asset_pb';
 
 interface SerializedProto {
   proto: string;
@@ -49,6 +54,8 @@ export const serialize = <VAL>(value: VAL): Serialized<VAL> => {
 const ProtosByType = {
   'penumbra.core.asset.v1.ValueView': ValueView,
   'penumbra.core.asset.v1.Metadata': Metadata,
+  'penumbra.core.asset.v1.Value': Value,
+  'penumbra.core.asset.v1.AssetId': AssetId,
 } as const;
 
 const deserializeProto = (value: SerializedProto): Message<any> => {


### PR DESCRIPTION
Follow up from: https://github.com/penumbra-zone/dex-explorer/pull/171

Does three things:

1 - Moves registry + ValueView assembly to react-query as it was a heavy load sending that info from server.
2 - Add symbol to icons in volume table
3 - Add link to inspect page from My Positions table

<img width="251" alt="Screenshot 2024-12-10 at 11 25 02 AM" src="https://github.com/user-attachments/assets/6fb443c8-f1bc-4a9c-8e28-afe845c66c77">
<img width="205" alt="Screenshot 2024-12-10 at 11 24 48 AM" src="https://github.com/user-attachments/assets/6b7ffbfe-e8ad-40d1-a216-66c86162223d">

