### PR TITLE
Don't calculate in constructor

### DIFF
--- a/src/pages/trade/ui/order-form/store/index.ts
+++ b/src/pages/trade/ui/order-form/store/index.ts
@@ -57,7 +57,6 @@ class OrderFormStore {
     makeAutoObservable(this);
 
     void this.calculateGasFee();
-    void this.calculateExchangeRate();
   }
 
   setType = (type: FormType): void => {


### PR DESCRIPTION
Currently the cause of an error toast on load:

<img width="395" alt="Screenshot 2024-12-12 at 9 48 17 PM" src="https://github.com/user-attachments/assets/4e6fd8cf-2615-4099-8554-b20fc1142694" />
