### PR TITLE
Over-fetching hook

### DIFF
--- a/src/pages/trade/api/book.ts
+++ b/src/pages/trade/api/book.ts
@@ -25,7 +25,7 @@ export const useBook = () => {
     },
   });
 
-  useRefetchOnNewBlock(query);
+  useRefetchOnNewBlock('routeBook', query);
 
   return query;
 };

--- a/src/pages/trade/api/candles.tsx
+++ b/src/pages/trade/api/candles.tsx
@@ -27,7 +27,7 @@ export const useCandles = (durationWindow: DurationWindow) => {
     },
   });
 
-  useRefetchOnNewBlock(query);
+  useRefetchOnNewBlock('candles', query);
 
   return query;
 };

--- a/src/pages/trade/model/useSummary.ts
+++ b/src/pages/trade/model/useSummary.ts
@@ -20,7 +20,7 @@ export const useSummary = (window: DurationWindow) => {
     },
   });
 
-  useRefetchOnNewBlock(query);
+  useRefetchOnNewBlock('summary', query);
 
   return query;
 };

--- a/src/shared/api/compact-block.ts
+++ b/src/shared/api/compact-block.ts
@@ -40,14 +40,23 @@ const startBlockHeightStream = async (transport: Transport, signal: AbortSignal)
   }
 };
 
-export const useRefetchOnNewBlock = ({ refetch }: UseQueryResult) => {
+const lastRefetchedBlockHeights = new Map<string, number>();
+
+export const useRefetchOnNewBlock = (queryKey: string, { refetch }: UseQueryResult) => {
   const { data: blockHeight } = useLatestBlockHeight();
+  const queryKeyString = JSON.stringify(queryKey);
 
   useEffect(() => {
-    if (blockHeight) {
+    if (!blockHeight) {
+      return;
+    }
+
+    const lastHeight = lastRefetchedBlockHeights.get(queryKeyString) ?? -1;
+    if (blockHeight > lastHeight) {
+      lastRefetchedBlockHeights.set(queryKeyString, blockHeight);
       void refetch();
     }
-  }, [blockHeight, refetch]);
+  }, [blockHeight, refetch, queryKeyString]);
 };
 
 export const LATEST_HEIGHT_QUERY_KEY = ['latestBlockHeight'];


### PR DESCRIPTION
The `useRefetchOnNewBlock()` is overfetching as there isn't a cache for the many re-render calls happening. 

Before/after fix:

https://github.com/user-attachments/assets/29b4b3c4-157a-4f41-ab47-546598a16ca9


