### PR TITLE
fix: make pair selector error visible and scrollable

### DIFF
--- a/src/pages/trade/ui/pair-selector.tsx
+++ b/src/pages/trade/ui/pair-selector.tsx
@@ -67,7 +67,7 @@ export const PairSelector = observer(({ disabled, dialogTitle }: PairSelectorPro
 
   if (error) {
     return (
-      <div className='overflow-scroll max-w-[200px] whitespace-nowrap'>
+      <div className='overflow-scroll max-w-[400px] whitespace-nowrap'>
         <Text detail color='destructive.light'>
           Error loading pair selector: {String(error)}
         </Text>

--- a/src/pages/trade/ui/pair-selector.tsx
+++ b/src/pages/trade/ui/pair-selector.tsx
@@ -17,7 +17,7 @@ import { PagePath } from '@/shared/const/pages.ts';
 import { usePathToMetadata } from '../model/use-path.ts';
 import { Skeleton } from '@/shared/ui/skeleton';
 import { Density } from '@penumbra-zone/ui/Density';
-
+import { Text } from '@penumbra-zone/ui/Text';
 const handleRouting = ({
   router,
   baseAsset,
@@ -66,7 +66,13 @@ export const PairSelector = observer(({ disabled, dialogTitle }: PairSelectorPro
   const { baseAsset, quoteAsset, error, isLoading } = usePathToMetadata();
 
   if (error) {
-    return <div>Error loading pair selector: ${String(error)}</div>;
+    return (
+      <div className='overflow-scroll max-w-[200px] whitespace-nowrap'>
+        <Text detail color='destructive.light'>
+          Error loading pair selector: {String(error)}
+        </Text>
+      </div>
+    );
   }
 
   if (isLoading || !baseAsset || !quoteAsset) {


### PR DESCRIPTION
fixes #201 

makes pair selector error visible and scrollable

<img width="404" alt="image" src="https://github.com/user-attachments/assets/c9aa32b1-6f47-43f8-b7f4-5f855999485d" />
