### PR TITLE
feat: #221: market order improvements

### DIFF
--- a/app/app.tsx
+++ b/app/app.tsx
@@ -24,7 +24,7 @@ export const App = observer(({ children }: { children: ReactNode }) => {
 
   return (
     <QueryClientProvider client={queryClient}>
-      <TooltipProvider>
+      <TooltipProvider delayDuration={0}>
         <main className='relative z-0'>
           <SyncBar />
           <Header />

--- a/src/pages/trade/model/AssetInfo.ts
+++ b/src/pages/trade/model/AssetInfo.ts
@@ -13,6 +13,7 @@ export class AssetInfo {
    * @param the exponent to convert from base units to display units.
    */
   constructor(
+    public metadata: Metadata,
     public id: AssetId,
     public exponent: number,
     public symbol: string,
@@ -25,6 +26,7 @@ export class AssetInfo {
       return undefined;
     }
     return new AssetInfo(
+      metadata,
       metadata.penumbraAssetId,
       displayDenom.exponent,
       metadata.symbol,

--- a/src/pages/trade/ui/order-form/order-form-market.tsx
+++ b/src/pages/trade/ui/order-form/order-form-market.tsx
@@ -1,15 +1,15 @@
 import { observer } from 'mobx-react-lite';
 import { Button } from '@penumbra-zone/ui/Button';
 import { Text } from '@penumbra-zone/ui/Text';
+import { Slider as PenumbraSlider } from '@penumbra-zone/ui/Slider';
 import { connectionStore } from '@/shared/model/connection';
+import { ConnectButton } from '@/features/connect/connect-button';
 import { OrderInput } from './order-input';
 import { SegmentedControl } from './segmented-control';
-import { ConnectButton } from '@/features/connect/connect-button';
 import { InfoRowGasFee } from './info-row-gas-fee';
 import { InfoRowTradingFee } from './info-row-trading-fee';
 import { OrderFormStore } from './store/OrderFormStore';
-import { Slider as PenumbraSlider } from '@penumbra-zone/ui/Slider';
-import { InfoRow } from '@/pages/trade/ui/order-form/info-row';
+import { InfoRow } from './info-row';
 
 interface SliderProps {
   inputValue: string;
@@ -61,55 +61,26 @@ export const MarketOrderForm = observer(({ parentStore }: { parentStore: OrderFo
   return (
     <div className='p-4'>
       <SegmentedControl direction={store.direction} setDirection={store.setDirection} />
-      {isBuy ? (
-        <>
-          <div className='mb-4'>
-            <OrderInput
-              label={'Pay with'}
-              value={store.quoteInput}
-              onChange={store.setQuoteInput}
-              isEstimating={store.quoteEstimating}
-              isApproximately={false}
-              denominator={store.quoteAsset?.symbol}
-            />
-          </div>
-          <div className='mb-4'>
-            <OrderInput
-              disabled
-              label={'Buy'}
-              value={store.baseInput}
-              onChange={store.setBaseInput}
-              isEstimating={store.baseEstimating}
-              isApproximately={store.baseInputAmount !== 0}
-              denominator={store.baseAsset?.symbol}
-            />
-          </div>
-        </>
-      ) : (
-        <>
-          <div className='mb-4'>
-            <OrderInput
-              label={'Sell'}
-              value={store.baseInput}
-              onChange={store.setBaseInput}
-              isEstimating={store.baseEstimating}
-              isApproximately={false}
-              denominator={store.baseAsset?.symbol}
-            />
-          </div>
-          <div className='mb-4'>
-            <OrderInput
-              disabled
-              label={'Receive'}
-              value={store.quoteInput}
-              onChange={store.setQuoteInput}
-              isEstimating={store.quoteEstimating}
-              isApproximately={store.quoteInputAmount !== 0}
-              denominator={store.quoteAsset?.symbol}
-            />
-          </div>
-        </>
-      )}
+      <div className='mb-4'>
+        <OrderInput
+          label={isBuy ? 'Buy' : 'Sell'}
+          value={store.baseInput}
+          onChange={store.setBaseInput}
+          isEstimating={store.baseEstimating}
+          isApproximately={isBuy && store.baseInputAmount !== 0}
+          denominator={store.baseAsset?.symbol}
+        />
+      </div>
+      <div className='mb-4'>
+        <OrderInput
+          label={isBuy ? 'Pay with' : 'Receive'}
+          value={store.quoteInput}
+          onChange={store.setQuoteInput}
+          isEstimating={store.quoteEstimating}
+          isApproximately={!isBuy && store.quoteInputAmount !== 0}
+          denominator={store.quoteAsset?.symbol}
+        />
+      </div>
       <Slider
         inputValue={store.quoteInput}
         balance={store.quoteBalance}

--- a/src/pages/trade/ui/order-form/order-form-market.tsx
+++ b/src/pages/trade/ui/order-form/order-form-market.tsx
@@ -98,14 +98,14 @@ export const MarketOrderForm = observer(({ parentStore }: { parentStore: OrderFo
           <InfoRow
             label='Price impact'
             value={store.priceImpact}
-            toolTip='This percentage represents the effect of your trade on the token’s price'
+            toolTip='This percentage represents the effect of your trade on the token’s price.'
           />
         )}
         {store.unfilled && (
           <InfoRow
             label='Unfilled amount'
             value={store.unfilled}
-            toolTip='The portion of your trade that cannot be completed due to insufficient liquidity'
+            toolTip='The portion of your trade that cannot be completed due to insufficient liquidity.'
           />
         )}
       </div>

--- a/src/pages/trade/ui/order-form/order-form-market.tsx
+++ b/src/pages/trade/ui/order-form/order-form-market.tsx
@@ -9,6 +9,7 @@ import { InfoRowGasFee } from './info-row-gas-fee';
 import { InfoRowTradingFee } from './info-row-trading-fee';
 import { OrderFormStore } from './store/OrderFormStore';
 import { Slider as PenumbraSlider } from '@penumbra-zone/ui/Slider';
+import { InfoRow } from '@/pages/trade/ui/order-form/info-row';
 
 interface SliderProps {
   inputValue: string;
@@ -60,26 +61,55 @@ export const MarketOrderForm = observer(({ parentStore }: { parentStore: OrderFo
   return (
     <div className='p-4'>
       <SegmentedControl direction={store.direction} setDirection={store.setDirection} />
-      <div className='mb-4'>
-        <OrderInput
-          label={isBuy ? 'Buy' : 'Sell'}
-          value={store.baseInput}
-          onChange={store.setBaseInput}
-          isEstimating={store.baseEstimating}
-          isApproximately={isBuy && store.baseInputAmount !== 0}
-          denominator={store.baseAsset?.symbol}
-        />
-      </div>
-      <div className='mb-4'>
-        <OrderInput
-          label={isBuy ? 'Pay with' : 'Receive'}
-          value={store.quoteInput}
-          onChange={store.setQuoteInput}
-          isEstimating={store.quoteEstimating}
-          isApproximately={!isBuy && store.quoteInputAmount !== 0}
-          denominator={store.quoteAsset?.symbol}
-        />
-      </div>
+      {isBuy ? (
+        <>
+          <div className='mb-4'>
+            <OrderInput
+              label={'Pay with'}
+              value={store.quoteInput}
+              onChange={store.setQuoteInput}
+              isEstimating={store.quoteEstimating}
+              isApproximately={false}
+              denominator={store.quoteAsset?.symbol}
+            />
+          </div>
+          <div className='mb-4'>
+            <OrderInput
+              disabled
+              label={'Buy'}
+              value={store.baseInput}
+              onChange={store.setBaseInput}
+              isEstimating={store.baseEstimating}
+              isApproximately={store.baseInputAmount !== 0}
+              denominator={store.baseAsset?.symbol}
+            />
+          </div>
+        </>
+      ) : (
+        <>
+          <div className='mb-4'>
+            <OrderInput
+              label={'Sell'}
+              value={store.baseInput}
+              onChange={store.setBaseInput}
+              isEstimating={store.baseEstimating}
+              isApproximately={false}
+              denominator={store.baseAsset?.symbol}
+            />
+          </div>
+          <div className='mb-4'>
+            <OrderInput
+              disabled
+              label={'Receive'}
+              value={store.quoteInput}
+              onChange={store.setQuoteInput}
+              isEstimating={store.quoteEstimating}
+              isApproximately={store.quoteInputAmount !== 0}
+              denominator={store.quoteAsset?.symbol}
+            />
+          </div>
+        </>
+      )}
       <Slider
         inputValue={store.quoteInput}
         balance={store.quoteBalance}
@@ -93,6 +123,20 @@ export const MarketOrderForm = observer(({ parentStore }: { parentStore: OrderFo
           symbol={parentStore.gasFee.symbol}
           isLoading={parentStore.gasFeeLoading}
         />
+        {store.priceImpact && (
+          <InfoRow
+            label='Price impact'
+            value={store.priceImpact}
+            toolTip='This percentage represents the effect of your trade on the token’s price'
+          />
+        )}
+        {store.unfilled && (
+          <InfoRow
+            label='Unfilled amount'
+            value={store.unfilled}
+            toolTip='The portion of your trade that cannot be completed due to insufficient liquidity'
+          />
+        )}
       </div>
       <div className='mb-4'>
         {connected ? (

--- a/src/pages/trade/ui/order-form/order-input.tsx
+++ b/src/pages/trade/ui/order-form/order-input.tsx
@@ -17,6 +17,7 @@ export interface OrderInputProps {
   denominator?: string;
   max?: string | number;
   min?: string | number;
+  disabled?: boolean;
 }
 
 /**
@@ -35,6 +36,7 @@ export const OrderInput = forwardRef<HTMLInputElement, OrderInputProps>(
       denominator,
       max,
       min,
+      disabled,
     }: OrderInputProps,
     ref,
   ) => {
@@ -83,12 +85,15 @@ export const OrderInput = forwardRef<HTMLInputElement, OrderInputProps>(
                 'p-2 pt-7',
                 isApproximately && value ? 'pl-7' : 'pl-3',
                 'font-default text-textLg font-medium leading-textLg',
-                'hover:bg-other-tonalFill5 focus:outline-none focus:bg-other-tonalFill10',
+                !disabled &&
+                  'hover:bg-other-tonalFill5 focus:outline-none focus:bg-other-tonalFill10',
+                disabled && 'cursor-not-allowed',
                 '[&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none',
                 "[&[type='number']]:[-moz-appearance:textfield]",
               )}
               style={{ paddingRight: denomWidth + 20 }}
               value={value}
+              disabled={disabled}
               onChange={e => onChange?.(e.target.value)}
               onWheel={e => {
                 // Remove focus to prevent scroll changes

--- a/src/pages/trade/ui/order-form/store/MarketOrderFormStore.ts
+++ b/src/pages/trade/ui/order-form/store/MarketOrderFormStore.ts
@@ -7,8 +7,7 @@ import { AssetInfo } from '../../../model/AssetInfo';
 import { estimateAmount } from './estimate-amount';
 import { formatNumber } from '@penumbra-zone/types/amount';
 import { getMetadata } from '@penumbra-zone/getters/value-view';
-
-export type Direction = 'buy' | 'sell';
+import { Direction } from './types';
 
 export type LastEdited = 'Base' | 'Quote';
 
@@ -63,7 +62,7 @@ export class MarketOrderFormStore {
       this._quoteEstimating = true;
     });
     try {
-      const res = await estimateAmount(this._baseAsset, this._quoteAsset, input);
+      const res = await estimateAmount(this._baseAsset, this._quoteAsset, input, this.direction);
       if (res === undefined) {
         return;
       }
@@ -91,7 +90,7 @@ export class MarketOrderFormStore {
       this._baseEstimating = true;
     });
     try {
-      const res = await estimateAmount(this._quoteAsset, this._baseAsset, input);
+      const res = await estimateAmount(this._quoteAsset, this._baseAsset, input, this.direction);
       if (res === undefined) {
         return;
       }
@@ -111,6 +110,7 @@ export class MarketOrderFormStore {
     this.direction = x;
     this._unfilled = undefined;
     this._priceImpact = undefined;
+    void this.estimateQuote();
   };
 
   get baseInput(): string {
@@ -216,7 +216,7 @@ export class MarketOrderFormStore {
     if (this._priceImpact === undefined || Math.abs(this._priceImpact) < 0.001) {
       return;
     }
-    const percent = formatNumber(Math.abs(this._priceImpact) * 100, { precision: 3 });
+    const percent = formatNumber(this._priceImpact * 100, { precision: 3 });
     return `${percent}%`;
   }
 

--- a/src/pages/trade/ui/order-form/store/MarketOrderFormStore.ts
+++ b/src/pages/trade/ui/order-form/store/MarketOrderFormStore.ts
@@ -1,51 +1,10 @@
+import debounce from 'lodash/debounce';
 import { makeAutoObservable, reaction, runInAction } from 'mobx';
 import { AssetId, Value } from '@penumbra-zone/protobuf/penumbra/core/asset/v1/asset_pb';
 import { pnum } from '@penumbra-zone/types/pnum';
-import debounce from 'lodash/debounce';
 import { parseNumber } from '@/shared/utils/num';
-import { penumbra } from '@/shared/const/penumbra';
-import { SimulationService } from '@penumbra-zone/protobuf';
-import { SimulateTradeRequest } from '@penumbra-zone/protobuf/penumbra/core/component/dex/v1/dex_pb';
-import { openToast } from '@penumbra-zone/ui/Toast';
-import { AssetInfo } from '@/pages/trade/model/AssetInfo';
-
-const estimateAmount = async (
-  from: AssetInfo,
-  to: AssetInfo,
-  input: number,
-): Promise<number | undefined> => {
-  try {
-    const req = new SimulateTradeRequest({
-      input: from.value(input),
-      output: to.id,
-    });
-
-    const res = await penumbra.service(SimulationService).simulateTrade(req);
-
-    const amount = res.output?.output?.amount;
-    if (amount === undefined) {
-      throw new Error('Amount returned from swap simulation was undefined');
-    }
-    return pnum(amount, to.exponent).toNumber();
-  } catch (e) {
-    if (
-      e instanceof Error &&
-      ![
-        'ConnectError',
-        'PenumbraNotInstalledError',
-        'PenumbraProviderNotAvailableError',
-        'PenumbraProviderNotConnectedError',
-      ].includes(e.name)
-    ) {
-      openToast({
-        type: 'error',
-        message: e.name,
-        description: e.message,
-      });
-    }
-    return undefined;
-  }
-};
+import { AssetInfo } from '../../../model/AssetInfo';
+import { estimateAmount } from './estimate-amount';
 
 export type Direction = 'buy' | 'sell';
 

--- a/src/pages/trade/ui/order-form/store/MarketOrderFormStore.ts
+++ b/src/pages/trade/ui/order-form/store/MarketOrderFormStore.ts
@@ -1,10 +1,12 @@
 import debounce from 'lodash/debounce';
 import { makeAutoObservable, reaction, runInAction } from 'mobx';
-import { AssetId, Value } from '@penumbra-zone/protobuf/penumbra/core/asset/v1/asset_pb';
+import { AssetId, Value, ValueView } from '@penumbra-zone/protobuf/penumbra/core/asset/v1/asset_pb';
 import { pnum } from '@penumbra-zone/types/pnum';
 import { parseNumber } from '@/shared/utils/num';
 import { AssetInfo } from '../../../model/AssetInfo';
 import { estimateAmount } from './estimate-amount';
+import { formatNumber } from '@penumbra-zone/types/amount';
+import { getMetadata } from '@penumbra-zone/getters/value-view';
 
 export type Direction = 'buy' | 'sell';
 
@@ -26,6 +28,8 @@ export class MarketOrderFormStore {
   private _quoteAssetInput = '';
   private _baseEstimating = false;
   private _quoteEstimating = false;
+  private _priceImpact: number | undefined = undefined;
+  private _unfilled: ValueView | undefined = undefined;
   direction: Direction = 'buy';
   private _lastEdited: LastEdited = 'Base';
 
@@ -59,12 +63,14 @@ export class MarketOrderFormStore {
       this._quoteEstimating = true;
     });
     try {
-      const res = await estimateAmount(this._quoteAsset, this._baseAsset, input);
+      const res = await estimateAmount(this._baseAsset, this._quoteAsset, input);
       if (res === undefined) {
         return;
       }
       runInAction(() => {
-        this._quoteAssetInput = res.toString();
+        this._quoteAssetInput = res.amount.toString();
+        this._priceImpact = res.priceImpact;
+        this._unfilled = res.unfilled;
       });
     } finally {
       runInAction(() => {
@@ -85,12 +91,14 @@ export class MarketOrderFormStore {
       this._baseEstimating = true;
     });
     try {
-      const res = await estimateAmount(this._baseAsset, this._quoteAsset, input);
+      const res = await estimateAmount(this._quoteAsset, this._baseAsset, input);
       if (res === undefined) {
         return;
       }
       runInAction(() => {
-        this._baseAssetInput = res.toString();
+        this._baseAssetInput = res.amount.toString();
+        this._priceImpact = res.priceImpact;
+        this._unfilled = res.unfilled;
       });
     } finally {
       runInAction(() => {
@@ -101,6 +109,8 @@ export class MarketOrderFormStore {
 
   setDirection = (x: Direction) => {
     this.direction = x;
+    this._unfilled = undefined;
+    this._priceImpact = undefined;
   };
 
   get baseInput(): string {
@@ -171,12 +181,18 @@ export class MarketOrderFormStore {
     return this._lastEdited;
   }
 
+  clear() {
+    this._baseAssetInput = '';
+    this._quoteAssetInput = '';
+    this._unfilled = undefined;
+    this._priceImpact = undefined;
+  }
+
   setAssets(base: AssetInfo, quote: AssetInfo, resetInputs = false) {
     this._baseAsset = base;
     this._quoteAsset = quote;
     if (resetInputs) {
-      this._baseAssetInput = '';
-      this._quoteAssetInput = '';
+      this.clear();
     }
   }
 
@@ -186,6 +202,22 @@ export class MarketOrderFormStore {
 
   get quoteAsset(): undefined | AssetInfo {
     return this._quoteAsset;
+  }
+
+  get unfilled(): undefined | string {
+    if (!this._unfilled) {
+      return undefined;
+    }
+    const symbol = getMetadata(this._unfilled).symbol;
+    return `${pnum(this._unfilled).toNumber()} ${symbol}`;
+  }
+
+  get priceImpact(): undefined | string {
+    if (this._priceImpact === undefined || Math.abs(this._priceImpact) < 0.001) {
+      return;
+    }
+    const percent = formatNumber(Math.abs(this._priceImpact) * 100, { precision: 3 });
+    return `${percent}%`;
   }
 
   get plan(): undefined | MarketOrderPlan {

--- a/src/pages/trade/ui/order-form/store/calculate-price-impact.ts
+++ b/src/pages/trade/ui/order-form/store/calculate-price-impact.ts
@@ -1,0 +1,46 @@
+import { SwapExecution } from '@penumbra-zone/protobuf/penumbra/core/component/dex/v1/dex_pb';
+import { getAmountFromValue, getAssetIdFromValue } from '@penumbra-zone/getters/value';
+import { divideAmounts } from '@penumbra-zone/types/amount';
+import { AssetId, Value } from '@penumbra-zone/protobuf/penumbra/core/asset/v1/asset_pb';
+import { Amount } from '@penumbra-zone/protobuf/penumbra/core/num/v1/num_pb';
+
+const getMatchingAmount = (values: Value[], toMatch: AssetId): Amount => {
+  const match = values.find(v => toMatch.equals(v.assetId));
+  if (!match?.amount) {
+    throw new Error('No match in values array found');
+  }
+
+  return match.amount;
+};
+
+/**
+  Price impact is the change in price as a consequence of the trade's size. In SwapExecution, the
+  first trace in the array is the best execution for the swap. To calculate price impact, take
+  the price of the trade and see the % diff off the best execution trace.
+ */
+export const calculatePriceImpact = (swapExec?: SwapExecution): number | undefined => {
+  if (!swapExec?.traces.length || !swapExec.output || !swapExec.input) {
+    return undefined;
+  }
+
+  // Get the price of the estimate for the swap total
+  const inputAmount = getAmountFromValue(swapExec.input);
+  const outputAmount = getAmountFromValue(swapExec.output);
+  const swapEstimatePrice = divideAmounts(outputAmount, inputAmount);
+
+  // Get the price in the best execution trace
+  const inputAssetId = getAssetIdFromValue(swapExec.input);
+  const outputAssetId = getAssetIdFromValue(swapExec.output);
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- the check is done above
+  const bestTrace = swapExec.traces[0]!;
+  const bestInputAmount = getMatchingAmount(bestTrace.value, inputAssetId);
+  const bestOutputAmount = getMatchingAmount(bestTrace.value, outputAssetId);
+  const bestTraceEstimatedPrice = divideAmounts(bestOutputAmount, bestInputAmount);
+
+  // Difference = (priceB - priceA) / priceA
+  const percentDifference = swapEstimatePrice
+    .minus(bestTraceEstimatedPrice)
+    .div(bestTraceEstimatedPrice);
+
+  return percentDifference.toNumber();
+};

--- a/src/pages/trade/ui/order-form/store/estimate-amount.ts
+++ b/src/pages/trade/ui/order-form/store/estimate-amount.ts
@@ -1,5 +1,6 @@
-import { SimulateTradeRequest } from '@penumbra-zone/protobuf/penumbra/core/component/dex/v1/dex_pb';
 import { createClient } from '@connectrpc/connect';
+import { SimulateTradeRequest } from '@penumbra-zone/protobuf/penumbra/core/component/dex/v1/dex_pb';
+import { ValueView } from '@penumbra-zone/protobuf/penumbra/core/asset/v1/asset_pb';
 import { SimulationService } from '@penumbra-zone/protobuf';
 import { pnum } from '@penumbra-zone/types/pnum';
 import { openToast } from '@penumbra-zone/ui/Toast';
@@ -7,6 +8,14 @@ import { penumbra } from '@/shared/const/penumbra';
 import { connectionStore } from '@/shared/model/connection';
 import { getGrpcTransport } from '@/shared/api/transport';
 import { AssetInfo } from '../../../model/AssetInfo';
+import { calculatePriceImpact } from '@/pages/trade/ui/order-form/store/calculate-price-impact';
+import { toValueView } from '@/shared/utils/value-view';
+
+export interface EstimationResult {
+  amount: number;
+  unfilled?: ValueView;
+  priceImpact?: number;
+}
 
 /**
  * Simulates the transaction with given input and output assets.
@@ -16,7 +25,7 @@ export const estimateAmount = async (
   from: AssetInfo,
   to: AssetInfo,
   input: number,
-): Promise<number | undefined> => {
+): Promise<EstimationResult | undefined> => {
   try {
     const grpc = !connectionStore.connected ? await getGrpcTransport() : undefined;
 
@@ -33,7 +42,22 @@ export const estimateAmount = async (
     if (amount === undefined) {
       throw new Error('Amount returned from swap simulation was undefined');
     }
-    return pnum(amount, to.exponent).toNumber();
+
+    const unfilled =
+      res.unfilled?.amount &&
+      res.unfilled.assetId &&
+      (res.unfilled.amount.hi !== 0n || res.unfilled.amount.lo !== 0n)
+        ? toValueView({
+            amount: pnum(res.unfilled.amount).toNumber(),
+            metadata: from.metadata,
+          })
+        : undefined;
+
+    return {
+      unfilled,
+      amount: pnum(amount, to.exponent).toNumber(),
+      priceImpact: calculatePriceImpact(res.output),
+    };
   } catch (e) {
     if (
       e instanceof Error &&

--- a/src/pages/trade/ui/order-form/store/estimate-amount.ts
+++ b/src/pages/trade/ui/order-form/store/estimate-amount.ts
@@ -1,0 +1,55 @@
+import { SimulateTradeRequest } from '@penumbra-zone/protobuf/penumbra/core/component/dex/v1/dex_pb';
+import { createClient } from '@connectrpc/connect';
+import { SimulationService } from '@penumbra-zone/protobuf';
+import { pnum } from '@penumbra-zone/types/pnum';
+import { openToast } from '@penumbra-zone/ui/Toast';
+import { penumbra } from '@/shared/const/penumbra';
+import { connectionStore } from '@/shared/model/connection';
+import { getGrpcTransport } from '@/shared/api/transport';
+import { AssetInfo } from '../../../model/AssetInfo';
+
+/**
+ * Simulates the transaction with given input and output assets.
+ * Works for both connected and disconnected accounts but must be used within MobX store.
+ */
+export const estimateAmount = async (
+  from: AssetInfo,
+  to: AssetInfo,
+  input: number,
+): Promise<number | undefined> => {
+  try {
+    const grpc = !connectionStore.connected ? await getGrpcTransport() : undefined;
+
+    const req = new SimulateTradeRequest({
+      input: from.value(input),
+      output: to.id,
+    });
+
+    const res = grpc
+      ? await createClient(SimulationService, grpc.transport).simulateTrade(req)
+      : await penumbra.service(SimulationService).simulateTrade(req);
+
+    const amount = res.output?.output?.amount;
+    if (amount === undefined) {
+      throw new Error('Amount returned from swap simulation was undefined');
+    }
+    return pnum(amount, to.exponent).toNumber();
+  } catch (e) {
+    if (
+      e instanceof Error &&
+      ![
+        'ConnectError',
+        'PenumbraNotInstalledError',
+        'PenumbraProviderNotAvailableError',
+        'PenumbraProviderNotConnectedError',
+      ].includes(e.name)
+    ) {
+      openToast({
+        type: 'error',
+        message: e.name,
+        description: e.message,
+      });
+    }
+    return undefined;
+  }
+};

--- a/src/pages/trade/ui/order-form/store/types.ts
+++ b/src/pages/trade/ui/order-form/store/types.ts
@@ -1,0 +1,1 @@
+export type Direction = 'buy' | 'sell';

--- a/src/shared/api/transport.ts
+++ b/src/shared/api/transport.ts
@@ -6,6 +6,7 @@ import { ViewService } from '@penumbra-zone/protobuf/penumbra/view/v1/view_conne
 import { envQueryFn } from '@/shared/api/env/env.ts';
 import { penumbra } from '@/shared/const/penumbra.ts';
 import { connectionStore } from '@/shared/model/connection';
+import { queryClient } from '@/shared/const/queryClient';
 
 const registryRpcChoices = async () => {
   const env = await envQueryFn();
@@ -67,10 +68,16 @@ const grpcTransportQueryFn = async () => {
   };
 };
 
+const getGrpcQueryOptions = () => ({
+  queryKey: ['grpcTransport', connectionStore.connected],
+  queryFn: grpcTransportQueryFn,
+  staleTime: Infinity,
+});
+
+export const getGrpcTransport = () => {
+  return queryClient.fetchQuery(getGrpcQueryOptions());
+};
+
 export const useGrpcTransport = () => {
-  return useQuery({
-    queryKey: ['grpcTransport', connectionStore.connected],
-    queryFn: grpcTransportQueryFn,
-    staleTime: Infinity,
-  });
+  return useQuery(getGrpcQueryOptions());
 };


### PR DESCRIPTION
Closes #221 

Features:
1. Allow estimations without connecting a wallet
2. Fix the invertion of the price estimation
3. Calculate the price impact of a trade and display it in the UI
4. Display the unfilled amount estimation if there's any

<img width="307" alt="image" src="https://github.com/user-attachments/assets/895533be-efa9-454a-937b-01f78c85028c" />
