### PR TITLE
fix: rework position rendering logic

### DIFF
--- a/src/pages/trade/model/positions.test.ts
+++ b/src/pages/trade/model/positions.test.ts
@@ -10,22 +10,29 @@ import {
   DenomUnit,
 } from '@penumbra-zone/protobuf/penumbra/core/asset/v1/asset_pb';
 import { compareAssetId } from '@/shared/math/position';
+import { pnum } from '@penumbra-zone/types/pnum';
+import { BigNumber } from 'bignumber.js';
 
 describe('positionsStore', () => {
   const id1 = new Uint8Array(Array(32).fill(0xaa));
   const id2 = new Uint8Array(Array(32).fill(0xbb));
+  const p1 = 2;
+  const p2 = 1;
+  const exponent1 = 6;
+  const exponent2 = 9;
+  const feeBps = 25;
 
   const createPosition = ({ r1, r2 }: { r1: bigint; r2: bigint }) => {
     return new Position({
       phi: {
         component: {
-          fee: 25,
+          fee: feeBps,
           p: {
-            lo: 1n,
+            lo: BigInt(p1),
             hi: 0n,
           },
           q: {
-            lo: 1n,
+            lo: BigInt(p2),
             hi: 0n,
           },
         },
@@ -62,12 +69,12 @@ describe('positionsStore', () => {
       new Metadata({
         penumbraAssetId: new AssetId({ inner: id1 }),
         display: 'asset1',
-        denomUnits: [new DenomUnit({ denom: 'asset1', exponent: 6 })],
+        denomUnits: [new DenomUnit({ denom: 'asset1', exponent: exponent1 })],
       }),
       new Metadata({
         penumbraAssetId: new AssetId({ inner: id2 }),
         display: 'asset2',
-        denomUnits: [new DenomUnit({ denom: 'asset2', exponent: 9 })],
+        denomUnits: [new DenomUnit({ denom: 'asset2', exponent: exponent2 })],
       }),
     ];
 
@@ -114,6 +121,59 @@ describe('positionsStore', () => {
       const orders = positionsStore.getOrdersByBaseQuoteAssets(asset1, asset2);
       expect(orders[0]?.direction).toEqual('Sell');
       expect(orders[1]).toEqual(undefined);
+    });
+  });
+
+  describe('getOrderValueViews', () => {
+    it('should return the correct value views for a buy order', () => {
+      const position = createPosition({
+        r1: 0n,
+        r2: pnum(12.123, exponent2).toBigInt(),
+      });
+
+      const [asset1, asset2] = positionsStore.getCalculatedAssets(position as ExecutedPosition);
+      const orders = positionsStore.getOrdersByBaseQuoteAssets(asset1, asset2);
+      const buyOrder = orders[0];
+
+      const valueViews = positionsStore.getOrderValueViews(buyOrder!);
+
+      const basePrice = (p1 / p2) * 10 ** (exponent1 - exponent2);
+      const effectivePrice = BigNumber(basePrice)
+        .minus(BigNumber(basePrice).times(feeBps).div(10000))
+        .toNumber();
+
+      expect(pnum(valueViews.amount).toNumber()).toEqual(
+        Number(
+          (
+            buyOrder?.quoteAsset.amount *
+            buyOrder?.quoteAsset.effectivePrice *
+            10 ** (exponent2 - exponent1)
+          ).toFixed(exponent1),
+        ),
+      );
+      expect(pnum(valueViews.basePrice).toNumber()).toEqual(basePrice);
+      expect(pnum(valueViews.effectivePrice).toNumber()).toEqual(effectivePrice);
+    });
+
+    it('should return the correct value views for a sell order', () => {
+      const position = createPosition({
+        r1: pnum(4.567, exponent1).toBigInt(),
+        r2: 0n,
+      });
+
+      const [asset1, asset2] = positionsStore.getCalculatedAssets(position as ExecutedPosition);
+      const orders = positionsStore.getOrdersByBaseQuoteAssets(asset1, asset2);
+      const sellOrder = orders[0];
+
+      const valueViews = positionsStore.getOrderValueViews(sellOrder!);
+      const basePrice = (p1 / p2) * 10 ** (exponent1 - exponent2);
+      const effectivePrice = BigNumber(basePrice)
+        .minus(BigNumber(basePrice).times(feeBps).div(10000))
+        .toNumber();
+
+      expect(pnum(valueViews.amount).toNumber()).toEqual(4.567);
+      expect(pnum(valueViews.basePrice).toNumber()).toEqual(basePrice);
+      expect(pnum(valueViews.effectivePrice).toNumber()).toEqual(effectivePrice);
     });
   });
 });

--- a/src/pages/trade/model/positions.test.ts
+++ b/src/pages/trade/model/positions.test.ts
@@ -72,6 +72,11 @@ describe('positionsStore', () => {
     ];
 
     positionsStore.setAssets(assets);
+
+    // Assert that id1 and id2 are in canonical order
+    expect(
+      compareAssetId(new AssetId({ inner: id1 }), new AssetId({ inner: id2 })),
+    ).toBeLessThanOrEqual(0);
   });
 
   describe('getOrdersByBaseQuoteAssets', () => {
@@ -80,10 +85,6 @@ describe('positionsStore', () => {
         r1: 100n,
         r2: 100n,
       });
-
-      const correctOrder =
-        compareAssetId(new AssetId({ inner: id1 }), new AssetId({ inner: id2 })) <= 0;
-      console.log('TCL: correctOrder', correctOrder);
 
       const [asset1, asset2] = positionsStore.getCalculatedAssets(position as ExecutedPosition);
       const orders = positionsStore.getOrdersByBaseQuoteAssets(asset1, asset2);

--- a/src/pages/trade/model/positions.test.ts
+++ b/src/pages/trade/model/positions.test.ts
@@ -145,8 +145,8 @@ describe('positionsStore', () => {
       expect(pnum(valueViews.amount).toNumber()).toEqual(
         Number(
           (
-            buyOrder?.quoteAsset.amount *
-            buyOrder?.quoteAsset.effectivePrice *
+            buyOrder!.quoteAsset.amount.toNumber() *
+            buyOrder!.quoteAsset.effectivePrice.toNumber() *
             10 ** (exponent2 - exponent1)
           ).toFixed(exponent1),
         ),

--- a/src/pages/trade/model/positions.test.ts
+++ b/src/pages/trade/model/positions.test.ts
@@ -1,0 +1,118 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+import {
+  Position,
+  PositionState_PositionStateEnum,
+} from '@penumbra-zone/protobuf/penumbra/core/component/dex/v1/dex_pb';
+import { ExecutedPosition, positionsStore } from './positions';
+import {
+  Metadata,
+  AssetId,
+  DenomUnit,
+} from '@penumbra-zone/protobuf/penumbra/core/asset/v1/asset_pb';
+import { compareAssetId } from '@/shared/math/position';
+
+describe('positionsStore', () => {
+  const id1 = new Uint8Array(Array(32).fill(0xaa));
+  const id2 = new Uint8Array(Array(32).fill(0xbb));
+
+  const createPosition = ({ r1, r2 }: { r1: bigint; r2: bigint }) => {
+    return new Position({
+      phi: {
+        component: {
+          fee: 25,
+          p: {
+            lo: 1n,
+            hi: 0n,
+          },
+          q: {
+            lo: 1n,
+            hi: 0n,
+          },
+        },
+        pair: {
+          asset1: {
+            inner: id1,
+          },
+          asset2: {
+            inner: id2,
+          },
+        },
+      },
+      nonce: new Uint8Array(Array(32).fill(0xcc)),
+      state: {
+        state: PositionState_PositionStateEnum.OPENED,
+        sequence: 0n,
+      },
+      reserves: {
+        r1: {
+          lo: r1,
+          hi: 0n,
+        },
+        r2: {
+          lo: r2,
+          hi: 0n,
+        },
+      },
+      closeOnFill: false,
+    });
+  };
+
+  beforeAll(() => {
+    const assets: Metadata[] = [
+      new Metadata({
+        penumbraAssetId: new AssetId({ inner: id1 }),
+        display: 'asset1',
+        denomUnits: [new DenomUnit({ denom: 'asset1', exponent: 6 })],
+      }),
+      new Metadata({
+        penumbraAssetId: new AssetId({ inner: id2 }),
+        display: 'asset2',
+        denomUnits: [new DenomUnit({ denom: 'asset2', exponent: 9 })],
+      }),
+    ];
+
+    positionsStore.setAssets(assets);
+  });
+
+  describe('getOrdersByBaseQuoteAssets', () => {
+    it('should return a buy and sell order when both assets have reserves', () => {
+      const position = createPosition({
+        r1: 100n,
+        r2: 100n,
+      });
+
+      const correctOrder =
+        compareAssetId(new AssetId({ inner: id1 }), new AssetId({ inner: id2 })) <= 0;
+      console.log('TCL: correctOrder', correctOrder);
+
+      const [asset1, asset2] = positionsStore.getCalculatedAssets(position as ExecutedPosition);
+      const orders = positionsStore.getOrdersByBaseQuoteAssets(asset1, asset2);
+      expect(orders[0]?.direction).toEqual('Buy');
+      expect(orders[1]?.direction).toEqual('Sell');
+    });
+
+    it('should return a buy order when only the quote asset has reserves', () => {
+      const position = createPosition({
+        r1: 0n,
+        r2: 100n,
+      });
+
+      const [asset1, asset2] = positionsStore.getCalculatedAssets(position as ExecutedPosition);
+      const orders = positionsStore.getOrdersByBaseQuoteAssets(asset1, asset2);
+      expect(orders[0]?.direction).toEqual('Buy');
+      expect(orders[1]).toEqual(undefined);
+    });
+
+    it('should return a sell order when only the base asset has reserves', () => {
+      const position = createPosition({
+        r1: 100n,
+        r2: 0n,
+      });
+
+      const [asset1, asset2] = positionsStore.getCalculatedAssets(position as ExecutedPosition);
+      const orders = positionsStore.getOrdersByBaseQuoteAssets(asset1, asset2);
+      expect(orders[0]?.direction).toEqual('Sell');
+      expect(orders[1]).toEqual(undefined);
+    });
+  });
+});

--- a/src/pages/trade/model/positions.ts
+++ b/src/pages/trade/model/positions.ts
@@ -46,6 +46,7 @@ export interface CalculatedAsset {
   reserves: Amount;
 }
 
+// interface to avoid checking if the nested values exist on a Position
 export interface ExecutedPosition {
   phi: {
     component: BareTradingFunction;

--- a/src/pages/trade/model/positions.ts
+++ b/src/pages/trade/model/positions.ts
@@ -289,7 +289,6 @@ class PositionsStore {
   };
 
   getCalculatedAssets(position: ExecutedPosition): [CalculatedAsset, CalculatedAsset] {
-    /* eslint-disable curly -- makes code more concise */
     const { phi, reserves } = position;
     const { pair, component } = phi;
 

--- a/src/pages/trade/model/positions.ts
+++ b/src/pages/trade/model/positions.ts
@@ -142,7 +142,10 @@ class PositionsStore {
     this.currentPair = [baseAsset, quoteAsset];
   };
 
-  getOrdersByBaseQuoteAssets = (baseAsset: CalculatedAsset, quoteAsset: CalculatedAsset) => {
+  getOrdersByBaseQuoteAssets = (
+    baseAsset: CalculatedAsset,
+    quoteAsset: CalculatedAsset,
+  ): { direction: string; baseAsset: CalculatedAsset; quoteAsset: CalculatedAsset }[] => {
     if (!isZero(baseAsset.reserves) && !isZero(quoteAsset.reserves)) {
       return [
         {

--- a/src/pages/trade/ui/positions-current-value.tsx
+++ b/src/pages/trade/ui/positions-current-value.tsx
@@ -16,7 +16,9 @@ export const PositionsCurrentValue = ({ order }: { order: DisplayPosition['order
   if (order.direction === 'Buy') {
     return (
       <ValueViewComponent
-        valueView={pnum(quoteAsset.amount, quoteAsset.exponent).toValueView(quoteAsset.asset)}
+        valueView={pnum(quoteAsset.amount.toNumber(), quoteAsset.exponent).toValueView(
+          quoteAsset.asset,
+        )}
         density='slim'
       />
     );
@@ -24,7 +26,7 @@ export const PositionsCurrentValue = ({ order }: { order: DisplayPosition['order
 
   return (
     <ValueViewComponent
-      valueView={pnum(baseAsset.amount * marketPrice, quoteAsset.exponent).toValueView(
+      valueView={pnum(baseAsset.amount.toNumber() * marketPrice, quoteAsset.exponent).toValueView(
         quoteAsset.asset,
       )}
       density='slim'

--- a/src/pages/trade/ui/positions-current-value.tsx
+++ b/src/pages/trade/ui/positions-current-value.tsx
@@ -3,23 +3,31 @@ import { useMarketPrice } from '../model/useMarketPrice';
 import { ValueViewComponent } from '@penumbra-zone/ui/ValueView';
 import { LoadingCell } from './market-trades';
 import { pnum } from '@penumbra-zone/types/pnum';
-import { DisplayAsset } from '../model/positions';
+import { DisplayPosition } from '../model/positions';
 
-export const PositionsCurrentValue = ({
-  baseAsset,
-  quoteAsset,
-}: {
-  baseAsset: DisplayAsset;
-  quoteAsset: DisplayAsset;
-}) => {
+export const PositionsCurrentValue = ({ order }: { order: DisplayPosition['orders'][number] }) => {
+  const { baseAsset, quoteAsset } = order;
   const marketPrice = useMarketPrice(baseAsset.asset.symbol, quoteAsset.asset.symbol);
 
-  return marketPrice ? (
+  if (!marketPrice) {
+    return <LoadingCell />;
+  }
+
+  if (order.direction === 'Buy') {
+    return (
+      <ValueViewComponent
+        valueView={pnum(quoteAsset.amount, quoteAsset.exponent).toValueView(quoteAsset.asset)}
+        density='slim'
+      />
+    );
+  }
+
+  return (
     <ValueViewComponent
-      valueView={pnum(marketPrice, quoteAsset.exponent).toValueView(quoteAsset.asset)}
+      valueView={pnum(baseAsset.amount * marketPrice, quoteAsset.exponent).toValueView(
+        quoteAsset.asset,
+      )}
       density='slim'
     />
-  ) : (
-    <LoadingCell />
   );
 };

--- a/src/pages/trade/ui/positions.tsx
+++ b/src/pages/trade/ui/positions.tsx
@@ -321,8 +321,7 @@ const Positions = observer(({ showInactive }: { showInactive: boolean }) => {
                       <Table.Td density='slim'>
                         <div className='flex flex-col gap-4'>
                           {position.orders.map((order, i) => (
-
-                              <PositionsCurrentValue key={i} order={order} />
+                            <PositionsCurrentValue key={i} order={order} />
                           ))}
                         </div>
                       </Table.Td>

--- a/src/pages/trade/ui/positions.tsx
+++ b/src/pages/trade/ui/positions.tsx
@@ -321,11 +321,8 @@ const Positions = observer(({ showInactive }: { showInactive: boolean }) => {
                       <Table.Td density='slim'>
                         <div className='flex flex-col gap-4'>
                           {position.orders.map((order, i) => (
-                            <PositionsCurrentValue
-                              key={i}
-                              baseAsset={order.baseAsset}
-                              quoteAsset={order.quoteAsset}
-                            />
+
+                              <PositionsCurrentValue key={i} order={order} />
                           ))}
                         </div>
                       </Table.Td>

--- a/src/pages/trade/ui/positions.tsx
+++ b/src/pages/trade/ui/positions.tsx
@@ -258,7 +258,7 @@ const Positions = observer(({ showInactive }: { showInactive: boolean }) => {
                             <ValueViewComponent
                               key={i}
                               valueView={order.amount}
-                              trailingZeros={true}
+                              trailingZeros={false}
                               density='slim'
                             />
                           ))}
@@ -293,7 +293,7 @@ const Positions = observer(({ showInactive }: { showInactive: boolean }) => {
                               <div>
                                 <ValueViewComponent
                                   valueView={order.effectivePrice}
-                                  trailingZeros={true}
+                                  trailingZeros={false}
                                   density='slim'
                                 />
                               </div>
@@ -309,16 +309,12 @@ const Positions = observer(({ showInactive }: { showInactive: boolean }) => {
                       <Table.Td density='slim'>
                         <div className='flex flex-col gap-4'>
                           {position.orders.map((order, i) => (
-                            <Text
+                            <ValueViewComponent
                               key={i}
-                              as='div'
-                              detailTechnical
-                              color='text.primary'
-                              whitespace='nowrap'
-                            >
-                              {pnum(order.basePrice).toFormattedString()}{' '}
-                              {order.baseAsset.asset.symbol}
-                            </Text>
+                              valueView={order.basePrice}
+                              trailingZeros={false}
+                              density='slim'
+                            />
                           ))}
                         </div>
                       </Table.Td>

--- a/src/shared/math/position.test.ts
+++ b/src/shared/math/position.test.ts
@@ -75,3 +75,68 @@ describe('planToPosition', () => {
     expect(pnum(position.reserves?.r2).toNumber()).toEqual(7e8);
   });
 });
+
+describe('renderPositions', () => {
+  it('works for plans with no exponent', () => {
+    const position = planToPosition({
+      baseAsset: {
+        id: ASSET_A,
+        exponent: 0,
+      },
+      quoteAsset: {
+        id: ASSET_B,
+        exponent: 0,
+      },
+      price: 20.5,
+      feeBps: 100,
+      baseReserves: 1000,
+      quoteReserves: 2000,
+    });
+    expect(position.phi?.component?.fee).toEqual(100);
+    expect(getPrice(position)).toEqual(20.5);
+    expect(pnum(position.reserves?.r1).toNumber()).toEqual(1000);
+    expect(pnum(position.reserves?.r2).toNumber()).toEqual(2000);
+  });
+
+  it('works for plans with identical exponent', () => {
+    const position = planToPosition({
+      baseAsset: {
+        id: ASSET_A,
+        exponent: 6,
+      },
+      quoteAsset: {
+        id: ASSET_B,
+        exponent: 6,
+      },
+      price: 12.34,
+      feeBps: 100,
+      baseReserves: 5,
+      quoteReserves: 7,
+    });
+    expect(position.phi?.component?.fee).toEqual(100);
+    expect(getPrice(position)).toEqual(12.34);
+    expect(pnum(position.reserves?.r1).toNumber()).toEqual(5e6);
+    expect(pnum(position.reserves?.r2).toNumber()).toEqual(7e6);
+  });
+
+  it('works for plans with different exponents', () => {
+    const position = planToPosition({
+      baseAsset: {
+        id: ASSET_A,
+        exponent: 6,
+      },
+      quoteAsset: {
+        id: ASSET_B,
+        exponent: 8,
+      },
+      price: 12.34,
+      feeBps: 100,
+      baseReserves: 5,
+      quoteReserves: 7,
+    });
+    expect(position.phi?.component?.fee).toEqual(100);
+    expect(getPrice(position) * 10 ** (6 - 8)).toEqual(12.34);
+    expect(pnum(position.reserves?.r1).toNumber()).toEqual(5e6);
+    expect(pnum(position.reserves?.r2).toNumber()).toEqual(7e8);
+  });
+});

--- a/src/shared/math/position.ts
+++ b/src/shared/math/position.ts
@@ -10,6 +10,7 @@ import { pnum } from '@penumbra-zone/types/pnum';
 import BigNumber from 'bignumber.js';
 
 export const compareAssetId = (a: AssetId, b: AssetId): number => {
+  // The asset ids are serialized using LE, so this is checking the MSB.
   for (let i = 31; i >= 0; --i) {
     const a_i = a.inner[i] ?? -Infinity;
     const b_i = b.inner[i] ?? -Infinity;


### PR DESCRIPTION
This PR:
- supersedes #235 
- rework the position rendering logic and fix a collection of issues with price calculations and exponent handling
- lays the groundwork for doing renders based on a "well-known numeraire" list
- fills the current value column with the current value of the portfolio

This is the byproduct of a pairing session and discussion with @JasonMHasperhoven. There are string of low hanging fruits that we can refactor. **We will do this later**. Next steps should be to:
- add a couple tests (scaffolding is setup)
- do basic end to end actions using the dex
- use this work as a stepping stone to ship a smooth range liquidity experience