### PR TITLE
fix: #250: filter assets in pair selector correctly

### DIFF
--- a/src/pages/trade/ui/order-form/store/OrderFormStore.ts
+++ b/src/pages/trade/ui/order-form/store/OrderFormStore.ts
@@ -263,10 +263,11 @@ function getAccountAddress(subAccounts: AddressView[] | undefined) {
 const orderFormStore = new OrderFormStore();
 
 export const useOrderFormStore = () => {
+  const { subaccount } = connectionStore;
   const { data: assets } = useRegistryAssets();
   const { data: subAccounts } = useSubaccounts();
   const { address, addressIndex } = getAccountAddress(subAccounts);
-  const { data: balances } = useBalances(addressIndex);
+  const { data: balances } = useBalances(addressIndex?.account ?? subaccount);
   const { baseAsset, quoteAsset } = usePathToMetadata();
   const marketPrice = useMarketPrice();
 

--- a/src/pages/trade/ui/pair-selector/search-results.tsx
+++ b/src/pages/trade/ui/pair-selector/search-results.tsx
@@ -14,6 +14,7 @@ import {
   groupAndSortBalances,
   AssetSelectorValue,
   isBalancesResponse,
+  filterAssets as filterUnswappableAssets,
 } from '@penumbra-zone/ui/AssetSelector';
 import { Button } from '@penumbra-zone/ui/Button';
 import { useAssets } from '@/shared/api/assets';
@@ -54,7 +55,7 @@ const mergeOptions = (
 ): AssetSelectorValue[] => {
   const grouped = groupAndSortBalances(balances);
   const balancesPerAccount = grouped.find(group => group[0] === account.toString())?.[1] ?? [];
-  const filteredAssets = assets
+  const filteredAssets = filterUnswappableAssets(assets)
     .filter(
       asset =>
         !balancesPerAccount.some(
@@ -71,7 +72,7 @@ export const SearchResults = observer(
     const { subaccount } = connectionStore;
 
     const { data: assets } = useAssets();
-    const { data: balances } = useBalances();
+    const { data: balances } = useBalances(subaccount);
 
     const merged = mergeOptions(assets ?? [], balances ?? [], subaccount);
     const filtered = useFilteredAssets(merged, search ?? '');
@@ -99,8 +100,8 @@ export const SearchResults = observer(
               <div className='flex flex-col gap-1'>
                 {recent.map(asset => (
                   <Dialog.RadioItem
-                    key={asset.symbol}
-                    value={asset.symbol}
+                    key={`${asset.symbol}-${asset.display}`}
+                    value={`${asset.symbol}-${asset.display}`}
                     startAdornment={<AssetIcon metadata={asset} size='lg' />}
                     title={
                       <div className={asset.name ? '' : 'h-10 flex items-center'}>
@@ -141,18 +142,17 @@ export const SearchResults = observer(
 
                 return (
                   <Dialog.RadioItem
-                    key={asset.symbol}
-                    value={asset.symbol}
+                    key={`${asset.symbol}-${asset.display}`}
+                    value={`${asset.symbol}-${asset.display}`}
                     startAdornment={<AssetIcon metadata={asset} size='lg' />}
                     endAdornment={
                       balance && (
-                        <div className='[&_img]:hidden'>
-                          <ValueViewComponent
-                            showSymbol={false}
-                            context='table'
-                            valueView={balance.valueView}
-                          />
-                        </div>
+                        <ValueViewComponent
+                          showSymbol={false}
+                          showIcon={false}
+                          context='table'
+                          valueView={balance.valueView}
+                        />
                       )
                     }
                     title={

--- a/src/shared/api/balances.ts
+++ b/src/shared/api/balances.ts
@@ -5,18 +5,25 @@ import { connectionStore } from '@/shared/model/connection';
 import { useQuery } from '@tanstack/react-query';
 import { AddressIndex } from '@penumbra-zone/protobuf/penumbra/core/keys/v1/keys_pb';
 
-const fetchQuery = (accountFilter?: AddressIndex) => async (): Promise<BalancesResponse[]> => {
-  return Array.fromAsync(penumbra.service(ViewService).balances({ accountFilter }));
+const fetchQuery = (index?: number) => async (): Promise<BalancesResponse[]> => {
+  return Array.fromAsync(
+    penumbra.service(ViewService).balances({
+      accountFilter:
+        typeof index !== 'undefined'
+          ? new AddressIndex({ account: index, randomizer: new Uint8Array(0) })
+          : undefined,
+    }),
+  );
 };
 
 /**
  * Fetches the `BalancesResponse[]` based on the provider connection state.
  * Must be used within the `observer` mobX HOC
  */
-export const useBalances = (accountFilter?: AddressIndex) => {
+export const useBalances = (index?: number) => {
   return useQuery({
-    queryKey: ['view-service-balances'],
-    queryFn: fetchQuery(accountFilter),
+    queryKey: ['view-service-balances', index],
+    queryFn: fetchQuery(index),
     enabled: connectionStore.connected,
   });
 };


### PR DESCRIPTION
Closes #250

- filters out lpNFTs and all other unswappable assets (votes, proposal nfts, auction nfts, delegations)
- shows balances per selected sub-account
- fixes the bug with non-unique keys in react map