### PR TITLE
explore page: data rendering

### DIFF
--- a/src/shared/api/server/summary/all.ts
+++ b/src/shared/api/server/summary/all.ts
@@ -72,6 +72,7 @@ export const getAllSummaries = async (
   );
 
   // Sorting by decreasing liquidity in the pool
+  // TODO: sort directly in SQL to avoid breaking server-side pagination
   const sortedSummaries = summaries.filter(Boolean).sort((a, b) => {
     if (!a || !b) {
       return 0;

--- a/src/shared/api/server/summary/all.ts
+++ b/src/shared/api/server/summary/all.ts
@@ -5,6 +5,8 @@ import { DurationWindow, durationWindows, isDurationWindow } from '@/shared/util
 import { adaptSummary, SummaryData } from '@/shared/api/server/summary/types.ts';
 import { AssetId, Metadata } from '@penumbra-zone/protobuf/penumbra/core/asset/v1/asset_pb';
 import { serialize, Serialized } from '@/shared/utils/serializer';
+import { getStablecoins } from '@/shared/utils/stables';
+import { getFormattedAmtFromValueView } from '@penumbra-zone/types/value-view';
 
 interface GetPairsParams {
   window: DurationWindow;
@@ -31,8 +33,7 @@ export const getAllSummaries = async (
   const registry = await registryClient.remote.get(chainId);
   const allAssets = registry.getAllAssets();
 
-  const stablecoins = allAssets.filter(asset => ['USDT', 'USDC', 'USDY'].includes(asset.symbol));
-  const usdc = stablecoins.find(asset => asset.symbol === 'USDC');
+  const { stablecoins, usdc } = getStablecoins(allAssets, 'USDC');
 
   const results = await pindexer.summaries({
     ...params,
@@ -66,11 +67,23 @@ export const getAllSummaries = async (
         return;
       }
 
-      return serialize(data);
+      return data;
     }),
   );
 
-  return summaries.filter(Boolean) as Serialized<SummaryData>[];
+  // Sorting by decreasing liquidity in the pool
+  const sortedSummaries = summaries.filter(Boolean).sort((a, b) => {
+    if (!a || !b) {
+      return 0;
+    }
+
+    const aLiquidity = Number(getFormattedAmtFromValueView(a.liquidity)) || 0;
+    const bLiquidity = Number(getFormattedAmtFromValueView(b.liquidity)) || 0;
+
+    return bLiquidity - aLiquidity;
+  });
+
+  return sortedSummaries.map(data => serialize(data)) as Serialized<SummaryData>[];
 };
 
 export type SummariesResponse = Serialized<SummaryData>[] | { error: string };

--- a/src/shared/api/server/summary/pairs.ts
+++ b/src/shared/api/server/summary/pairs.ts
@@ -9,6 +9,7 @@ import {
 import { ChainRegistryClient } from '@penumbra-labs/registry';
 import { toValueView } from '@/shared/utils/value-view';
 import { getDisplayDenomExponent } from '@penumbra-zone/getters/metadata';
+import { getStablecoins } from '@/shared/utils/stables';
 
 const getAssetById = (allAssets: Metadata[], id: Buffer): Metadata | undefined => {
   return allAssets.find(asset => {
@@ -34,8 +35,7 @@ export async function GET(): Promise<NextResponse<PairsResponse>> {
   const registry = await registryClient.remote.get(chainId);
   const allAssets = registry.getAllAssets();
 
-  const stablecoins = allAssets.filter(asset => ['USDT', 'USDC', 'USDY'].includes(asset.symbol));
-  const usdc = stablecoins.find(asset => asset.symbol === 'USDC');
+  const { stablecoins, usdc } = getStablecoins(allAssets, 'USDC');
 
   const results = await pindexer.pairs({
     // eslint-disable-next-line @typescript-eslint/non-nullable-type-assertion-style -- usdc is defined

--- a/src/shared/api/server/summary/single.ts
+++ b/src/shared/api/server/summary/single.ts
@@ -4,6 +4,7 @@ import { ChainRegistryClient } from '@penumbra-labs/registry';
 import { durationWindows, isDurationWindow } from '@/shared/utils/duration.ts';
 import { adaptSummary, SummaryResponse } from '@/shared/api/server/summary/types.ts';
 import { serialize, Serialized } from '@/shared/utils/serializer';
+import { getStablecoins } from '@/shared/utils/stables';
 
 export async function GET(req: NextRequest): Promise<NextResponse<Serialized<SummaryResponse>>> {
   const chainId = process.env['PENUMBRA_CHAIN_ID'];
@@ -34,8 +35,8 @@ export async function GET(req: NextRequest): Promise<NextResponse<Serialized<Sum
 
   // TODO: Add getMetadataBySymbol() helper to registry npm package
   const allAssets = registry.getAllAssets();
-  const stablecoins = allAssets.filter(asset => ['USDT', 'USDC', 'USDY'].includes(asset.symbol));
-  const usdc = stablecoins.find(asset => asset.symbol === 'USDC');
+
+  const { usdc } = getStablecoins(allAssets, 'USDC');
 
   const baseAssetMetadata = allAssets.find(
     a => a.symbol.toLowerCase() === baseAssetSymbol.toLowerCase(),

--- a/src/shared/utils/stables.ts
+++ b/src/shared/utils/stables.ts
@@ -1,6 +1,8 @@
 import { Metadata } from '@penumbra-zone/protobuf/penumbra/core/asset/v1/asset_pb';
 
-/// Utility for retrieving stablecoin metadata
+/**
+ * Utility for retrieving stablecoin metadata
+ */
 export const getStablecoins = (
   allAssets: Metadata[],
   stablecoin: string,

--- a/src/shared/utils/stables.ts
+++ b/src/shared/utils/stables.ts
@@ -1,0 +1,11 @@
+import { Metadata } from '@penumbra-zone/protobuf/penumbra/core/asset/v1/asset_pb';
+
+/// Utility for retrieving stablecoin metadata
+export const getStablecoins = (
+  allAssets: Metadata[],
+  stablecoin: string,
+): { stablecoins: Metadata[]; usdc?: Metadata } => {
+  const stablecoins = allAssets.filter(asset => ['USDT', 'USDC', 'USDY'].includes(asset.symbol));
+  const usdc = stablecoins.find(asset => asset.symbol === stablecoin);
+  return { stablecoins, usdc };
+};


### PR DESCRIPTION
addresses feedback in https://github.com/penumbra-zone/dex-explorer/pull/223 + sorts pairs by decreasing liquidity

-----------------

<img width="953" alt="Screenshot 2025-01-13 at 8 32 56 PM" src="https://github.com/user-attachments/assets/b81bbfd9-2cc2-4029-99f6-421138451b46" />