### PR TITLE
fix: #245: hide `undefined` in status popover

### DIFF
--- a/src/shared/model/status/index.ts
+++ b/src/shared/model/status/index.ts
@@ -57,7 +57,7 @@ class StatusState {
     this.error = undefined;
     this.syncing = status.catchingUp;
     this.fullSyncHeight = status.fullSyncHeight;
-    this.latestKnownBlockHeight = status.catchingUp ? undefined : status.fullSyncHeight;
+    this.latestKnownBlockHeight = status.fullSyncHeight;
     this.syncPercent = status.catchingUp ? 0 : 1;
     this.syncPercentStringified = status.catchingUp ? '0%' : '100%';
   }

--- a/src/shared/model/status/index.ts
+++ b/src/shared/model/status/index.ts
@@ -57,7 +57,7 @@ class StatusState {
     this.error = undefined;
     this.syncing = status.catchingUp;
     this.fullSyncHeight = status.fullSyncHeight;
-    this.latestKnownBlockHeight = status.fullSyncHeight;
+    this.latestKnownBlockHeight = status.catchingUp ? undefined : status.fullSyncHeight;
     this.syncPercent = status.catchingUp ? 0 : 1;
     this.syncPercentStringified = status.catchingUp ? '0%' : '100%';
   }

--- a/src/widgets/header/ui/status-popover.tsx
+++ b/src/widgets/header/ui/status-popover.tsx
@@ -19,7 +19,7 @@ export const StatusPopover = observer(() => {
     }
 
     if (loading) {
-      return null;
+      return <Pill context='technical-caution'>Loading...</Pill>;
     }
 
     if (!syncing) {
@@ -54,7 +54,7 @@ export const StatusPopover = observer(() => {
                   <Text technical>Block Height</Text>
                   <Pill context='technical-default'>
                     {latestKnownBlockHeight !== fullSyncHeight
-                      ? `${fullSyncHeight} of ${latestKnownBlockHeight}`
+                      ? `${fullSyncHeight}${latestKnownBlockHeight ? ` of ${latestKnownBlockHeight}` : ''}`
                       : `${latestKnownBlockHeight}`}
                   </Pill>
                 </div>


### PR DESCRIPTION
Closes #245 

- Stopped displaying `undefined` in the status popover
- Added 'loading' state to the popover – before it was just opening a popover with 'Status' text and nothing else