### PR TITLE
fix: #158: check if wallet is on wrong chain and disconnect

### DIFF
--- a/src/shared/api/transport.ts
+++ b/src/shared/api/transport.ts
@@ -2,7 +2,6 @@ import { ChainRegistryClient } from '@penumbra-labs/registry';
 import { sample } from 'lodash';
 import { useQuery } from '@tanstack/react-query';
 import { createGrpcWebTransport } from '@connectrpc/connect-web';
-import { ViewService } from '@penumbra-zone/protobuf/penumbra/view/v1/view_connect';
 import { envQueryFn } from '@/shared/api/env/env.ts';
 import { penumbra } from '@/shared/const/penumbra.ts';
 import { connectionStore } from '@/shared/model/connection';
@@ -22,34 +21,12 @@ const registryRpcChoices = async () => {
   }
 };
 
-// Verifies that the Dex explorer backend chain id matches the one Prax is connected to
-const walletOnWrongChain = async () => {
-  // If wallet is not connected, nothing to compare it to
-  if (!connectionStore.connected) {
-    return false;
-  }
-
-  const { parameters } = await penumbra.service(ViewService).appParameters({});
-  const walletChainId = parameters?.chainId;
-  if (!walletChainId) {
-    throw new Error('Unable to retrieve chain id from wallet');
-  }
-
-  const env = await envQueryFn();
-  return !!walletChainId && env.PENUMBRA_CHAIN_ID !== walletChainId;
-};
-
 enum TransportType {
   PRAX,
   GRPC_WEB,
 }
 
 const grpcTransportQueryFn = async () => {
-  const wrongChain = await walletOnWrongChain();
-  if (wrongChain) {
-    throw new Error('Wallet connected to a different chain than backend');
-  }
-
   if (connectionStore.connected && penumbra.transport) {
     return { transport: penumbra.transport, type: TransportType.PRAX };
   }

--- a/src/shared/model/connection/index.ts
+++ b/src/shared/model/connection/index.ts
@@ -7,6 +7,8 @@ import {
 import { makeAutoObservable } from 'mobx';
 import { openToast } from '@penumbra-zone/ui/Toast';
 import { penumbra } from '@/shared/const/penumbra';
+import { ViewService } from '@penumbra-zone/protobuf';
+import { envQueryFn } from '@/shared/api/env/env';
 
 class ConnectionStateStore {
   connected = false;
@@ -44,6 +46,7 @@ class ConnectionStateStore {
     try {
       await penumbra.connect(connected);
       this.setConnected(true);
+      await this.checkWrongChain();
     } catch (error) {
       /* no-op */
     }
@@ -52,6 +55,7 @@ class ConnectionStateStore {
   async connect(provider: string) {
     try {
       await penumbra.connect(provider);
+      await this.checkWrongChain();
     } catch (error) {
       if (error instanceof Error && error.cause) {
         if (error.cause === PenumbraRequestFailure.Denied) {
@@ -83,6 +87,24 @@ class ConnectionStateStore {
       console.error(error);
     } finally {
       window.location.reload();
+    }
+  }
+
+  // Checks if the connected wallet's chainId is the same as DEX's chainId. Disconnects if not.
+  async checkWrongChain() {
+    const [parameters, env] = await Promise.all([
+      penumbra.service(ViewService).appParameters({}),
+      await envQueryFn(),
+    ]);
+
+    const walletChainId = parameters.parameters?.chainId;
+    const dexChainId = env.PENUMBRA_CHAIN_ID;
+
+    if (!walletChainId || walletChainId !== dexChainId) {
+      alert(
+        `Connection denied. Your wallet is connected to the wrong chain "${walletChainId}". Please connect to "${dexChainId}".`,
+      );
+      void this.disconnect();
     }
   }
 


### PR DESCRIPTION
Closes #158 

Using `alert` here instead of `openToast` because this check requires us to disconnect user from the DEX. Disconnect causes a page reload, so the tooltip won't persist.

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/ae1d5c86-b1b0-432b-9f54-e7bcc3e9ed97" />
