### PR TITLE
fix: #268: disable slider for empty balances

### DIFF
--- a/src/pages/trade/ui/order-form/order-form-market.tsx
+++ b/src/pages/trade/ui/order-form/order-form-market.tsx
@@ -31,6 +31,7 @@ const Slider = observer(
             step={1}
             value={value}
             showValue={false}
+            disabled={!balance}
             onChange={x => setBalanceFraction(x / 10)}
             showTrackGaps={true}
             trackGapBackground='base.black'
@@ -82,8 +83,8 @@ export const MarketOrderForm = observer(({ parentStore }: { parentStore: OrderFo
         />
       </div>
       <Slider
-        inputValue={store.quoteInput}
-        balance={store.quoteBalance}
+        inputValue={isBuy ? store.quoteInput : store.baseInput}
+        balance={isBuy ? store.quoteBalance : store.baseBalance}
         balanceDisplay={store.balance}
         setBalanceFraction={x => store.setBalanceFraction(x)}
       />

--- a/src/pages/trade/ui/order-form/store/MarketOrderFormStore.ts
+++ b/src/pages/trade/ui/order-form/store/MarketOrderFormStore.ts
@@ -167,6 +167,13 @@ export class MarketOrderFormStore {
     return pnum(this._quoteAsset.balance, this._quoteAsset.exponent).toNumber();
   }
 
+  get baseBalance(): undefined | number {
+    if (!this._baseAsset?.balance) {
+      return undefined;
+    }
+    return pnum(this._baseAsset.balance, this._baseAsset.exponent).toNumber();
+  }
+
   setBalanceFraction(x: number) {
     const clamped = Math.max(0.0, Math.min(1.0, x));
     if (this.direction === 'buy' && this._quoteAsset?.balance) {


### PR DESCRIPTION
Closes #268 

- Disables the Slider if the balance of controlled asset is empty. Tried removing Slider but disabling is better UI
- For 'Sell' tab, uses base asset instead of quote asset

<img width="324" alt="image" src="https://github.com/user-attachments/assets/39d35649-0c8c-44dd-a40d-ad6833297001" />
