### PR TITLE
subaccounts: fix subaccount mapping

### DIFF
--- a/src/pages/trade/ui/order-form/store/OrderFormStore.ts
+++ b/src/pages/trade/ui/order-form/store/OrderFormStore.ts
@@ -245,8 +245,28 @@ export class OrderFormStore {
   }
 }
 
+/**
+ * Finds the subaccount in subAccounts where the address index matches `connectionStore.subaccount`, properly
+ * handling non-1:1 mappings by iterating through address views.
+ */
+const findMatchingSubaccount = (subaccounts: AddressView[] | undefined, targetAccount: number) => {
+  if (!subaccounts) {
+    return undefined;
+  }
+
+  return subaccounts.find(subaccount => {
+    const addressView = subaccount.addressView;
+    if (addressView.case === 'decoded') {
+      return addressView.value.index?.account === targetAccount;
+    } else {
+      return undefined;
+    }
+  });
+};
+
 function getAccountAddress(subAccounts: AddressView[] | undefined) {
-  const subAccount = subAccounts ? subAccounts[connectionStore.subaccount] : undefined;
+  const matchedSubaccount = findMatchingSubaccount(subAccounts, connectionStore.subaccount);
+  const subAccount = subAccounts ? matchedSubaccount : undefined;
   let addressIndex = undefined;
   let address = undefined;
   const addressView = subAccount?.addressView;


### PR DESCRIPTION
fixes https://github.com/penumbra-zone/dex-explorer/issues/243

properly [indexes](https://github.com/penumbra-zone/dex-explorer/blob/main/src/pages/trade/ui/order-form/store/OrderFormStore.ts#L249) the subAccounts array coming out of [useSubaccounts()](https://github.com/penumbra-zone/dex-explorer/blob/main/src/pages/trade/ui/order-form/store/OrderFormStore.ts#L268)

------------------

https://github.com/user-attachments/assets/cf6a80b6-e5b6-400f-8f6b-8fe3609c12ae
