### PR TITLE
fix: we can withdraw auto-closing positions

### DIFF
--- a/src/pages/trade/model/positions.ts
+++ b/src/pages/trade/model/positions.ts
@@ -15,10 +15,10 @@ import { connectionStore } from '@/shared/model/connection';
 import { AddressIndex } from '@penumbra-zone/protobuf/penumbra/core/keys/v1/keys_pb';
 import { isZero } from '@penumbra-zone/types/amount';
 import { penumbra } from '@/shared/const/penumbra.ts';
-import { DexService } from '@penumbra-zone/protobuf';
+import { ViewService } from '@penumbra-zone/protobuf';
 import { openToast } from '@penumbra-zone/ui/Toast';
 import { pnum } from '@penumbra-zone/types/pnum';
-import { positionIdFromBech32 } from '@penumbra-zone/bech32m/plpid';
+import { bech32mPositionId, positionIdFromBech32 } from '@penumbra-zone/bech32m/plpid';
 import { updatePositionsQuery } from '@/pages/trade/api/positions';
 import { BigNumber } from 'bignumber.js';
 
@@ -107,39 +107,72 @@ class PositionsStore {
     try {
       this.setLoading(true);
 
-      // Fetching latest position data as the planner request requires current reserves + pair
-      const promises = positions.map(({ id }) =>
-        penumbra.service(DexService).liquidityPositionById({ positionId: id }),
-      );
-      const latestPositionData = await Promise.all(promises);
+      // Our goal here is to withdraw all the closed position in this subaccount.
+      // Problem:
+      // 1. Auto-closing position switch to `Closed` without user input
+      // 2. We are building a list of positions to withdraw based on the latest on-chain state.
+      // 3. This list might contain position for which we do not yet own an associated closed LP NFT.
+      // Solution:
+      // 1. Track auto-closing positions that we are going to withdraw
+      // 2. Inspect our balance to check if we have an associated opened NFT
+      // 3. If that's the case, add a `PositionClose` action to the TPR.
+      // Later, we can improve the general explorer data flow, for now we should just ship this and
+      // make this flow work. This is, at the moment, the **ONLY** thing that matters.
 
-      // a position can be closed remotely, but not yet closed locally
-      // in this case we need to generate an nft to be able to withdraw
-      // it and include it in the planner request
-      const positionIdsToClose = positions
-        .map(({ id, position }, i) => ({
+      // First track all the positions we want to withdraw.
+      const positionWithdraws = positions
+        .filter(({ position }) => {
+          return position.state?.state === PositionState_PositionStateEnum.CLOSED;
+        })
+        .map(({ id, position }) => ({
           positionId: id,
-          prevState: position.state,
-          nextState: latestPositionData[i]?.data?.state,
-        }))
-        .filter(
-          ({ prevState, nextState }) =>
-            prevState?.state === PositionState_PositionStateEnum.OPENED &&
-            nextState?.state === PositionState_PositionStateEnum.CLOSED,
+          tradingPair: position?.phi?.pair,
+          reserves: position?.reserves,
+        }));
+
+      // Return early if there's no work to do.
+      if (!positionWithdraws.length) {
+        return;
+      }
+
+      // TODO(jason): not sure if this is duplicating code, feel free to move it out somewhere less disruptive.
+      async function asyncIterableToArray<T>(asyncIterable: AsyncIterable<T>): Promise<T[]> {
+        const array: T[] = [];
+        for await (const item of asyncIterable) {
+          array.push(item);
+        }
+        return array;
+      }
+
+      // Query the balance, ignoring the subaccount index for now.
+      const balances = await asyncIterableToArray(penumbra.service(ViewService).balances({}));
+
+      // We collect a list of position ids that are currently opened.
+      const openedPositionIdStrings = balances
+        ?.filter(
+          ({ balanceView }) =>
+            balanceView?.valueView?.case === 'knownAssetId' &&
+            (balanceView?.valueView?.value as any)?.metadata?.base?.startsWith('lpnft_opened_'),
         )
-        .map(({ positionId }) => positionId);
+        .map(
+          ({ balanceView }) =>
+            (balanceView?.valueView?.value as any)?.metadata?.base?.replace('lpnft_opened_', '') ||
+            '',
+        );
 
-      const positionWithdraws = positions.map(({ id }, i) => ({
-        positionId: id,
-        tradingPair: latestPositionData[i]?.data?.phi?.pair,
-        reserves: latestPositionData[i]?.data?.reserves,
-      }));
-
-      const positionCloses = positionIdsToClose.length
-        ? positionWithdraws.filter(position =>
-            positionIdsToClose.some(id => id.equals(position.positionId)),
-          )
-        : undefined;
+      // First, we filter for positions that are closed.
+      // Then, we filter for mismatched positions.
+      const positionCloses = positions
+        .filter(
+          // Start by filtering for auto-closing position that are closed on-chain.
+          ({ position }) => position.state?.state === PositionState_PositionStateEnum.CLOSED,
+        )
+        .filter(({ id }) => {
+          const idStr = bech32mPositionId(id);
+          // Now check if id is in openedPositionIdStrings
+          return openedPositionIdStrings?.includes(idStr);
+        })
+        .map(({ id: positionId }) => ({ positionId }));
 
       const planReq = new TransactionPlannerRequest({
         positionWithdraws,

--- a/src/pages/trade/model/positions.ts
+++ b/src/pages/trade/model/positions.ts
@@ -126,8 +126,8 @@ class PositionsStore {
         })
         .map(({ id, position }) => ({
           positionId: id,
-          tradingPair: position?.phi?.pair,
-          reserves: position?.reserves,
+          tradingPair: position.phi?.pair,
+          reserves: position.reserves,
         }));
 
       // Return early if there's no work to do.
@@ -149,14 +149,16 @@ class PositionsStore {
 
       // We collect a list of position ids that are currently opened.
       const openedPositionIdStrings = balances
-        ?.filter(
+        .filter(
           ({ balanceView }) =>
-            balanceView?.valueView?.case === 'knownAssetId' &&
-            (balanceView?.valueView?.value as any)?.metadata?.base?.startsWith('lpnft_opened_'),
+            balanceView?.valueView.case === 'knownAssetId' &&
+            balanceView.valueView.value.metadata?.base.startsWith('lpnft_opened_'),
         )
         .map(
           ({ balanceView }) =>
-            (balanceView?.valueView?.value as any)?.metadata?.base?.replace('lpnft_opened_', '') ||
+            (balanceView?.valueView.case === 'knownAssetId' &&
+              // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- Short-circuits properly
+              balanceView.valueView.value.metadata?.base.replace('lpnft_opened_', '')) ||
             '',
         );
 
@@ -170,7 +172,7 @@ class PositionsStore {
         .filter(({ id }) => {
           const idStr = bech32mPositionId(id);
           // Now check if id is in openedPositionIdStrings
-          return openedPositionIdStrings?.includes(idStr);
+          return openedPositionIdStrings.includes(idStr);
         })
         .map(({ id: positionId }) => ({ positionId }));
 


### PR DESCRIPTION
This PR fix withdrawals of auto-closing positions (#241).

Unfortunately, the approach we workshopped in #282 does not work because the `PositionStore` is already given a list of positions directly fetched from the DEX RPC service (latest state). This was an oversight on my part.

The code is hacky, maybe one could say that it sucks (?), but it works and we should **spend no time** trying to make it structurally better. We can fix linting, but let's keep it minimal. Our attention should be directed to the opened TODOs. 