### PR TITLE
explorer: basic execution stream support

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@penumbra-zone/protobuf": "^7.0.0",
     "@penumbra-zone/transport-dom": "^7.5.0",
     "@penumbra-zone/types": "^27.1.0",
-    "@penumbra-zone/ui": "^13.8.1",
+    "@penumbra-zone/ui": "^13.9.0",
     "@penumbra-zone/wasm": "^37.0.0",
     "@radix-ui/react-icons": "^1.3.2",
     "@rehooks/component-size": "^1.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,8 +66,8 @@ importers:
         specifier: ^27.1.0
         version: 27.1.0(@bufbuild/protobuf@1.10.0)(@penumbra-zone/bech32m@11.0.0(@penumbra-zone/protobuf@7.0.0(@bufbuild/protobuf@1.10.0)))(@penumbra-zone/getters@21.0.0(@bufbuild/protobuf@1.10.0)(@penumbra-zone/bech32m@11.0.0(@penumbra-zone/protobuf@7.0.0(@bufbuild/protobuf@1.10.0)))(@penumbra-zone/protobuf@7.0.0(@bufbuild/protobuf@1.10.0)))(@penumbra-zone/protobuf@7.0.0(@bufbuild/protobuf@1.10.0))
       '@penumbra-zone/ui':
-        specifier: ^13.8.1
-        version: 13.8.1(@bufbuild/protobuf@1.10.0)(@types/react-dom@18.3.2)(@types/react@18.3.14)
+        specifier: ^13.9.0
+        version: 13.9.0(@bufbuild/protobuf@1.10.0)(@types/react-dom@18.3.2)(@types/react@18.3.14)
       '@penumbra-zone/wasm':
         specifier: ^37.0.0
         version: 37.0.0(@bufbuild/protobuf@1.10.0)(@penumbra-zone/bech32m@11.0.0(@penumbra-zone/protobuf@7.0.0(@bufbuild/protobuf@1.10.0)))(@penumbra-zone/protobuf@7.0.0(@bufbuild/protobuf@1.10.0))(@penumbra-zone/types@27.1.0(@bufbuild/protobuf@1.10.0)(@penumbra-zone/bech32m@11.0.0(@penumbra-zone/protobuf@7.0.0(@bufbuild/protobuf@1.10.0)))(@penumbra-zone/getters@21.0.0(@bufbuild/protobuf@1.10.0)(@penumbra-zone/bech32m@11.0.0(@penumbra-zone/protobuf@7.0.0(@bufbuild/protobuf@1.10.0)))(@penumbra-zone/protobuf@7.0.0(@bufbuild/protobuf@1.10.0)))(@penumbra-zone/protobuf@7.0.0(@bufbuild/protobuf@1.10.0)))
@@ -1776,8 +1776,8 @@ packages:
       '@penumbra-zone/getters': 21.0.0
       '@penumbra-zone/protobuf': 7.0.0
 
-  '@penumbra-zone/ui@13.8.1':
-    resolution: {integrity: sha512-nJ8IHq1gOkfYiSBCfpPF6/mAHQKU5GO/XB0lHADBltPrJzzkzQVkEyt8sJ3I8n3VkSiqZzhffngsfxNOT1/SSg==}
+  '@penumbra-zone/ui@13.9.0':
+    resolution: {integrity: sha512-NtI4GVps1jLYuX9Vggq2TNodBkZt/1VwQcgNFGBc2F6OUTRSnOl0xqESBguMtZJsHB6rM93w5UYsK8IlrbXKCw==}
 
   '@penumbra-zone/wasm@37.0.0':
     resolution: {integrity: sha512-UEnvAzGdNqai2ZTe+GCfRdJ2DAZlxRYmp6/ZnbeW4q6PSoGaLmX+KqtS2lWOBYqkJh6x+xQvIrb7HGY6jxk/Cg==}
@@ -7418,7 +7418,7 @@ snapshots:
       lodash: 4.17.21
       zod: 3.23.8
 
-  '@penumbra-zone/ui@13.8.1(@bufbuild/protobuf@1.10.0)(@types/react-dom@18.3.2)(@types/react@18.3.14)':
+  '@penumbra-zone/ui@13.9.0(@bufbuild/protobuf@1.10.0)(@types/react-dom@18.3.2)(@types/react@18.3.14)':
     dependencies:
       '@penumbra-zone/bech32m': 11.0.0(@penumbra-zone/protobuf@7.0.0(@bufbuild/protobuf@1.10.0))
       '@penumbra-zone/getters': 21.0.0(@bufbuild/protobuf@1.10.0)(@penumbra-zone/bech32m@11.0.0(@penumbra-zone/protobuf@7.0.0(@bufbuild/protobuf@1.10.0)))(@penumbra-zone/protobuf@7.0.0(@bufbuild/protobuf@1.10.0))

--- a/scripts/generate-pindexer-schema.ts
+++ b/scripts/generate-pindexer-schema.ts
@@ -12,6 +12,7 @@ const pindexerTableWhitelist = [
   'dex_ex_position_state',
   'dex_ex_position_reserves',
   'dex_ex_position_withdrawals',
+  'dex_ex_batch_swap_traces',
   'dex_ex_metadata',
 ];
 

--- a/src/pages/trade/api/recent-executions.ts
+++ b/src/pages/trade/api/recent-executions.ts
@@ -3,45 +3,6 @@ import { useRefetchOnNewBlock } from '@/shared/api/compact-block.ts';
 import { usePathSymbols } from '@/pages/trade/model/use-path.ts';
 import { apiFetch } from '@/shared/utils/api-fetch.ts';
 import { RecentExecution } from '@/shared/api/server/recent-executions.ts';
-import { registryQueryFn } from '@/shared/api/registry.ts';
-import { Registry } from '@penumbra-labs/registry';
-import { formatAmount } from '@penumbra-zone/types/amount';
-import { getDisplayDenomExponent } from '@penumbra-zone/getters/metadata';
-import { calculateDisplayPrice } from '@/shared/utils/price-conversion.ts';
-import BigNumber from 'bignumber.js';
-
-export interface RecentExecutionVV {
-  kind: 'buy' | 'sell';
-  amount: string;
-  price: string;
-  timestamp: string;
-  hops: number;
-}
-
-const addVV = (res: RecentExecution[], registry: Registry): RecentExecutionVV[] => {
-  return res.map(r => {
-    if (!r.amount.assetId || !r.amount.amount) {
-      throw new Error('No asseId or Amount passed for recent execution');
-    }
-    const baseMetadata = registry.getMetadata(r.amount.assetId);
-    const baseDisplayDenomExponent = getDisplayDenomExponent.optional(baseMetadata) ?? 0;
-
-    const quoteMetadata = registry.getMetadata(r.price.assetId);
-    const price = calculateDisplayPrice(r.price.amount, baseMetadata, quoteMetadata);
-
-    return {
-      kind: r.kind,
-      hops: r.hops,
-      amount: formatAmount({
-        amount: r.amount.amount,
-        exponent: baseDisplayDenomExponent,
-        decimalPlaces: 4,
-      }),
-      price: new BigNumber(price).toFormat(4),
-      timestamp: r.timestamp,
-    };
-  });
-};
 
 const LIMIT = 10;
 
@@ -51,15 +12,11 @@ export const useRecentExecutions = () => {
   const query = useQuery({
     queryKey: ['recent-executions', baseSymbol, quoteSymbol],
     queryFn: async () => {
-      const results = await apiFetch<RecentExecution[]>('/api/recent-executions', {
+      return apiFetch<RecentExecution[]>('/api/recent-executions', {
         baseAsset: baseSymbol,
         quoteAsset: quoteSymbol,
         limit: String(LIMIT),
       });
-
-      const registry = await registryQueryFn();
-
-      return addVV(results, registry);
     },
   });
 

--- a/src/pages/trade/api/recent-executions.ts
+++ b/src/pages/trade/api/recent-executions.ts
@@ -15,6 +15,7 @@ export interface RecentExecutionVV {
   amount: string;
   price: string;
   timestamp: string;
+  hops: number;
 }
 
 const addVV = (res: RecentExecution[], registry: Registry): RecentExecutionVV[] => {
@@ -30,6 +31,7 @@ const addVV = (res: RecentExecution[], registry: Registry): RecentExecutionVV[] 
 
     return {
       kind: r.kind,
+      hops: r.hops,
       amount: formatAmount({
         amount: r.amount.amount,
         exponent: baseDisplayDenomExponent,

--- a/src/pages/trade/ui/market-trades.tsx
+++ b/src/pages/trade/ui/market-trades.tsx
@@ -81,8 +81,10 @@ export const MarketTrades = () => {
               variant={index !== data.length - 1 ? 'cell' : 'lastCell'}
               loading={isLoading}
             >
-              <span className={trade.hops <= 2 ? 'text-text-primary' : 'text-text-special'}>
-                {trade.hops === 2 ? 'Direct' : pluralize(trade.hops - 2, 'Hop', 'Hops')}
+              <span className={trade.hops.length <= 2 ? 'text-text-primary' : 'text-text-special'}>
+                {trade.hops.length === 2
+                  ? 'Direct'
+                  : pluralize(trade.hops.length - 2, 'Hop', 'Hops')}
               </span>
             </TableCell>
           </div>

--- a/src/pages/trade/ui/market-trades.tsx
+++ b/src/pages/trade/ui/market-trades.tsx
@@ -1,10 +1,13 @@
-import { ReactNode } from 'react';
 import { useAutoAnimate } from '@formkit/auto-animate/react';
+import { Fragment, ReactNode } from 'react';
+import { ChevronRight } from 'lucide-react';
+import cn from 'clsx';
 import { TableCell } from '@penumbra-zone/ui/TableCell';
 import { Density } from '@penumbra-zone/ui/Density';
 import { Skeleton } from '@penumbra-zone/ui/Skeleton';
-import { useRecentExecutions } from '../api/recent-executions.ts';
+import { Text } from '@penumbra-zone/ui/Text';
 import { pluralize } from '@/shared/utils/pluralize';
+import { useRecentExecutions } from '../api/recent-executions.ts';
 
 export const Cell = ({ children }: { children: ReactNode }) => {
   return <div className='flex items-center py-1.5 px-3 min-h-12'>{children}</div>;
@@ -51,7 +54,13 @@ export const MarketTrades = () => {
         {error && <ErrorState error={error} />}
 
         {data?.map((trade, index) => (
-          <div key={trade.timestamp + trade.amount} className='grid grid-cols-subgrid col-span-4'>
+          <div
+            key={trade.timestamp + trade.amount}
+            className={cn(
+              'relative grid grid-cols-subgrid col-span-4',
+              'group [&:hover>div:not(:last-child)]:invisible',
+            )}
+          >
             <TableCell
               numeric
               variant={index !== data.length - 1 ? 'cell' : 'lastCell'}
@@ -87,6 +96,23 @@ export const MarketTrades = () => {
                   : pluralize(trade.hops.length - 2, 'Hop', 'Hops')}
               </span>
             </TableCell>
+
+            {/* Route display that shows on hover */}
+            <div
+              className={cn(
+                'hidden group-hover:flex justify-center items-center gap-1',
+                'absolute left-0 right-0 w-full h-full px-4 z-30 select-none border-b border-b-other-tonalStroke',
+              )}
+            >
+              {trade.hops.map((token, index) => (
+                <Fragment key={index}>
+                  {index > 0 && <ChevronRight className='w-3 h-3 text-neutral-light text-xs' />}
+                  <Text tableItemSmall color='text.primary'>
+                    {token}
+                  </Text>
+                </Fragment>
+              ))}
+            </div>
           </div>
         ))}
       </div>

--- a/src/pages/trade/ui/market-trades.tsx
+++ b/src/pages/trade/ui/market-trades.tsx
@@ -4,6 +4,7 @@ import { TableCell } from '@penumbra-zone/ui/TableCell';
 import { Density } from '@penumbra-zone/ui/Density';
 import { Skeleton } from '@penumbra-zone/ui/Skeleton';
 import { useRecentExecutions } from '../api/recent-executions.ts';
+import { pluralize } from '@/shared/utils/pluralize';
 
 export const Cell = ({ children }: { children: ReactNode }) => {
   return <div className='flex items-center py-1.5 px-3 min-h-12'>{children}</div>;
@@ -62,14 +63,27 @@ export const MarketTrades = () => {
                 {trade.price}
               </span>
             </TableCell>
-            <TableCell cell numeric loading={isLoading}>
+            <TableCell
+              variant={index !== data.length - 1 ? 'cell' : 'lastCell'}
+              numeric
+              loading={isLoading}
+            >
               {trade.amount}
             </TableCell>
-            <TableCell cell numeric loading={isLoading}>
+            <TableCell
+              variant={index !== data.length - 1 ? 'cell' : 'lastCell'}
+              numeric
+              loading={isLoading}
+            >
               {formatLocalTime(trade.timestamp)}
             </TableCell>
-            <TableCell cell loading={isLoading}>
-              --
+            <TableCell
+              variant={index !== data.length - 1 ? 'cell' : 'lastCell'}
+              loading={isLoading}
+            >
+              <span className={trade.hops <= 2 ? 'text-text-primary' : 'text-text-special'}>
+                {trade.hops === 2 ? 'Direct' : pluralize(trade.hops - 2, 'Hop', 'Hops')}
+              </span>
             </TableCell>
           </div>
         ))}

--- a/src/pages/trade/ui/route-book/trade-row.tsx
+++ b/src/pages/trade/ui/route-book/trade-row.tsx
@@ -1,9 +1,10 @@
 import { Fragment } from 'react';
 import cn from 'clsx';
 import { ChevronRight } from 'lucide-react';
+import { getSymbolFromValueView } from '@penumbra-zone/getters/value-view';
 import { Text } from '@penumbra-zone/ui/Text';
 import { Trace } from '@/shared/api/server/book/types.ts';
-import { getSymbolFromValueView } from '@penumbra-zone/getters/value-view';
+import { pluralize } from '@/shared/utils/pluralize';
 import { formatNumber } from './utils';
 
 const SELL_BG_COLOR = 'rgba(175, 38, 38, 0.24)';
@@ -46,7 +47,7 @@ export const TradeRow = ({
         align='right'
         color={trace.hops.length <= 2 ? 'text.primary' : 'text.special'}
       >
-        {trace.hops.length === 2 ? 'Direct' : `${trace.hops.length - 2} Hops`}
+        {trace.hops.length === 2 ? 'Direct' : pluralize(trace.hops.length - 2, 'Hop', 'Hops')}
       </Text>
 
       {/* Route display that shows on hover */}

--- a/src/shared/api/server/recent-executions.ts
+++ b/src/shared/api/server/recent-executions.ts
@@ -34,10 +34,13 @@ const transformDbVal = ({
   // When we go from quote to base, we need to invert the price.
   // This makes sense: a UX-friendly price is always denominated in quote assets.
   const price = kind === 'sell' ? price_float : 1 / price_float;
+  // We always want to render the base amount in the trade, regardless of the direction.
+  // The `kind` field informs on the direction.
+  const baseAmount = kind === 'sell' ? input : output;
 
   return {
     kind,
-    amount: new Value({ amount: pnum(input).toAmount(), assetId: baseAssetId }),
+    amount: new Value({ amount: pnum(baseAmount).toAmount(), assetId: baseAssetId }),
     price: { amount: price, assetId: quoteAssetId },
     timestamp,
   };

--- a/src/shared/api/server/recent-executions.ts
+++ b/src/shared/api/server/recent-executions.ts
@@ -104,7 +104,7 @@ export async function GET(
   );
 
   const sellResponse = sellStream.map(data => transformDbVal({ ...data, kind: 'sell' }));
-const buyResponse = buyStream.map(data => transformDbVal({ ...data, kind: 'buy' }));
+  const buyResponse = buyStream.map(data => transformDbVal({ ...data, kind: 'buy' }));
   // Weave the two responses together based on timestamps
   const allResponse = [...sellResponse, ...buyResponse].sort(
     (a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime(),

--- a/src/shared/api/server/recent-executions.ts
+++ b/src/shared/api/server/recent-executions.ts
@@ -8,12 +8,12 @@ import { pnum } from '@penumbra-zone/types/pnum';
 const transformDbVal = ({
   asset_end,
   asset_start,
-  height,
   input,
   output,
   price_float,
   time,
   kind,
+  amount_hops,
 }: {
   asset_start: Buffer;
   asset_end: Buffer;
@@ -23,6 +23,7 @@ const transformDbVal = ({
   price_float: number;
   time: Date;
   kind: 'buy' | 'sell';
+  amount_hops: string[];
 }): RecentExecution => {
   const baseAssetId = new AssetId({
     inner: Uint8Array.from(asset_start),
@@ -43,6 +44,7 @@ const transformDbVal = ({
     amount: new Value({ amount: pnum(baseAmount).toAmount(), assetId: baseAssetId }),
     price: { amount: price, assetId: quoteAssetId },
     timestamp,
+    hops: amount_hops.length,
   };
 };
 
@@ -58,6 +60,7 @@ export interface RecentExecution {
   amount: Value;
   price: FloatValue;
   timestamp: string;
+  hops: number;
 }
 
 export async function GET(

--- a/src/shared/api/server/recent-executions.ts
+++ b/src/shared/api/server/recent-executions.ts
@@ -31,10 +31,14 @@ const transformDbVal = ({
 
   const timestamp = time.toISOString();
 
+  // When we go from quote to base, we need to invert the price.
+  // This makes sense: a UX-friendly price is always denominated in quote assets.
+  const price = kind === 'sell' ? price_float : 1 / price_float;
+
   return {
     kind,
     amount: new Value({ amount: pnum(input).toAmount(), assetId: baseAssetId }),
-    price: { amount: price_float, assetId: quoteAssetId },
+    price: { amount: price, assetId: quoteAssetId },
     timestamp,
   };
 };

--- a/src/shared/database/index.ts
+++ b/src/shared/database/index.ts
@@ -359,6 +359,7 @@ class Pindexer {
       .selectFrom('dex_ex_batch_swap_traces')
       .select([
         'amount_hops',
+        'asset_hops',
         'asset_end',
         'asset_hops',
         'asset_start',

--- a/src/shared/database/index.ts
+++ b/src/shared/database/index.ts
@@ -234,6 +234,8 @@ class Pindexer {
         'summary.the_window',
         'summary.direct_volume_over_window',
         'summary.swap_volume_over_window',
+        'summary.direct_volume_indexing_denom_over_window',
+        'summary.swap_volume_indexing_denom_over_window',
         'summary.liquidity',
         'summary.liquidity_then',
         'summary.trades_over_window',

--- a/src/shared/database/index.ts
+++ b/src/shared/database/index.ts
@@ -354,19 +354,24 @@ class Pindexer {
 
   async recentExecutions(base: AssetId, quote: AssetId, amount: number) {
     return await this.db
-      .selectFrom('dex_ex_position_executions')
+      .selectFrom('dex_ex_batch_swap_traces')
       .select([
-        'context_asset_end',
-        'context_asset_start',
-        'delta_1',
-        'delta_2',
-        'lambda_1',
-        'lambda_2',
-        'time',
+        'amount_hops',
+        'asset_end',
+        'asset_hops',
+        'asset_start',
+        'batch_input',
+        'batch_output',
+        'height',
+        'input',
+        'output',
+        'position_id_hops',
+        'price_float',
         'rowid',
+        'time',
       ])
-      .where('context_asset_start', '=', Buffer.from(base.inner))
-      .where('context_asset_end', '=', Buffer.from(quote.inner))
+      .where('asset_start', '=', Buffer.from(base.inner))
+      .where('asset_end', '=', Buffer.from(quote.inner))
       .orderBy('time', 'desc')
       .orderBy('rowid', 'asc') // Secondary sort by ID to maintain order within the same time frame
       .limit(amount)

--- a/src/shared/database/schema.ts
+++ b/src/shared/database/schema.ts
@@ -6,12 +6,19 @@ import { DurationWindow } from '@/shared/utils/duration.ts';
  * Please do not edit it manually.
  */
 
-import type { ColumnType } from 'kysely';
+import type { ColumnType } from "kysely";
 
-export type Generated<T> =
-  T extends ColumnType<infer S, infer I, infer U>
-    ? ColumnType<S, I | undefined, U>
-    : ColumnType<T, T | undefined, T>;
+export type ArrayType<T> = ArrayTypeImpl<T> extends (infer U)[]
+  ? U[]
+  : ArrayTypeImpl<T>;
+
+export type ArrayTypeImpl<T> = T extends ColumnType<infer S, infer I, infer U>
+  ? ColumnType<S[], I[], U[]>
+  : T[];
+
+export type Generated<T> = T extends ColumnType<infer S, infer I, infer U>
+  ? ColumnType<S, I | undefined, U>
+  : ColumnType<T, T | undefined, T>;
 
 export type Int8 = ColumnType<string, bigint | number | string, bigint | number | string>;
 
@@ -65,7 +72,22 @@ export interface DexExAggregateSummary {
   top_price_mover_end: Buffer;
   top_price_mover_start: Buffer;
   trades: number;
-  usdc_price: number | null;
+}
+
+export interface DexExBatchSwapTraces {
+  amount_hops: ArrayType<Numeric>;
+  asset_end: Buffer;
+  asset_hops: ArrayType<Buffer>;
+  asset_start: Buffer;
+  batch_input: Numeric;
+  batch_output: Numeric;
+  height: number;
+  input: Numeric;
+  output: Numeric;
+  position_id_hops: ArrayType<Buffer>;
+  price_float: number;
+  rowid: Generated<number>;
+  time: Timestamp;
 }
 
 export interface DexExMetadata {
@@ -80,6 +102,7 @@ export interface DexExPairsBlockSnapshot {
   id: Generated<number>;
   liquidity: number;
   price: number;
+  start_price_indexing_denom: number;
   swap_volume: number;
   time: Timestamp;
   trades: number;
@@ -88,6 +111,7 @@ export interface DexExPairsBlockSnapshot {
 export interface DexExPairsSummary {
   asset_end: Buffer;
   asset_start: Buffer;
+  direct_volume_indexing_denom_over_window: number;
   direct_volume_over_window: number;
   high: number;
   liquidity: number;
@@ -95,10 +119,10 @@ export interface DexExPairsSummary {
   low: number;
   price: number;
   price_then: number;
+  swap_volume_indexing_denom_over_window: number;
   swap_volume_over_window: number;
   the_window: DurationWindow;
   trades_over_window: number;
-  usdc_price: number | null;
 }
 
 export interface DexExPositionExecutions {
@@ -309,6 +333,7 @@ interface RawDB {
   _insights_validators: _InsightsValidators;
   block_details: BlockDetails;
   dex_ex_aggregate_summary: DexExAggregateSummary;
+  dex_ex_batch_swap_traces: DexExBatchSwapTraces;
   dex_ex_metadata: DexExMetadata;
   dex_ex_pairs_block_snapshot: DexExPairsBlockSnapshot;
   dex_ex_pairs_summary: DexExPairsSummary;
@@ -334,15 +359,5 @@ interface RawDB {
   supply_validators: SupplyValidators;
 }
 
-export type DB = Pick<
-  RawDB,
-  | 'dex_ex_aggregate_summary'
-  | 'dex_ex_pairs_block_snapshot'
-  | 'dex_ex_pairs_summary'
-  | 'dex_ex_price_charts'
-  | 'dex_ex_position_executions'
-  | 'dex_ex_position_state'
-  | 'dex_ex_position_reserves'
-  | 'dex_ex_position_withdrawals'
-  | 'dex_ex_metadata'
->;
+
+export type DB = Pick<RawDB, 'dex_ex_aggregate_summary' | 'dex_ex_pairs_block_snapshot' | 'dex_ex_pairs_summary' | 'dex_ex_price_charts' | 'dex_ex_position_executions' | 'dex_ex_position_state' | 'dex_ex_position_reserves' | 'dex_ex_position_withdrawals' | 'dex_ex_batch_swap_traces' | 'dex_ex_metadata'>;

--- a/src/shared/database/schema.ts
+++ b/src/shared/database/schema.ts
@@ -6,19 +6,17 @@ import { DurationWindow } from '@/shared/utils/duration.ts';
  * Please do not edit it manually.
  */
 
-import type { ColumnType } from "kysely";
+import type { ColumnType } from 'kysely';
 
-export type ArrayType<T> = ArrayTypeImpl<T> extends (infer U)[]
-  ? U[]
-  : ArrayTypeImpl<T>;
+export type ArrayType<T> = ArrayTypeImpl<T> extends (infer U)[] ? U[] : ArrayTypeImpl<T>;
 
-export type ArrayTypeImpl<T> = T extends ColumnType<infer S, infer I, infer U>
-  ? ColumnType<S[], I[], U[]>
-  : T[];
+export type ArrayTypeImpl<T> =
+  T extends ColumnType<infer S, infer I, infer U> ? ColumnType<S[], I[], U[]> : T[];
 
-export type Generated<T> = T extends ColumnType<infer S, infer I, infer U>
-  ? ColumnType<S, I | undefined, U>
-  : ColumnType<T, T | undefined, T>;
+export type Generated<T> =
+  T extends ColumnType<infer S, infer I, infer U>
+    ? ColumnType<S, I | undefined, U>
+    : ColumnType<T, T | undefined, T>;
 
 export type Int8 = ColumnType<string, bigint | number | string, bigint | number | string>;
 
@@ -359,5 +357,16 @@ interface RawDB {
   supply_validators: SupplyValidators;
 }
 
-
-export type DB = Pick<RawDB, 'dex_ex_aggregate_summary' | 'dex_ex_pairs_block_snapshot' | 'dex_ex_pairs_summary' | 'dex_ex_price_charts' | 'dex_ex_position_executions' | 'dex_ex_position_state' | 'dex_ex_position_reserves' | 'dex_ex_position_withdrawals' | 'dex_ex_batch_swap_traces' | 'dex_ex_metadata'>;
+export type DB = Pick<
+  RawDB,
+  | 'dex_ex_aggregate_summary'
+  | 'dex_ex_pairs_block_snapshot'
+  | 'dex_ex_pairs_summary'
+  | 'dex_ex_price_charts'
+  | 'dex_ex_position_executions'
+  | 'dex_ex_position_state'
+  | 'dex_ex_position_reserves'
+  | 'dex_ex_position_withdrawals'
+  | 'dex_ex_batch_swap_traces'
+  | 'dex_ex_metadata'
+>;

--- a/src/shared/database/schema.ts
+++ b/src/shared/database/schema.ts
@@ -70,6 +70,7 @@ export interface DexExAggregateSummary {
   top_price_mover_end: Buffer;
   top_price_mover_start: Buffer;
   trades: number;
+  usdc_price: number | null;
 }
 
 export interface DexExBatchSwapTraces {
@@ -121,6 +122,7 @@ export interface DexExPairsSummary {
   swap_volume_over_window: number;
   the_window: DurationWindow;
   trades_over_window: number;
+  usdc_price: number | null;
 }
 
 export interface DexExPositionExecutions {


### PR DESCRIPTION
This PR adds basic execution stream support, in particular it:
- updates the schema codegens to be compatible with the `dex_ex_batch_swap_traces` table
- rework the query transform combinator to render each trace cleanly
- makes two pindexer queries in each direction (base -> quote, and vice-versa), weaving the results together.

Working on a follow-up PR to make it a bit sleeker, compact and capture a sense of speed for the interface.

It would be good to transfer over the work done on the route book so that we can render each route when hovering on a cell in the recent trades list.

<img width="344" alt="Screenshot 2025-01-18 at 5 26 21 PM" src="https://github.com/user-attachments/assets/87d63a18-a9a0-4b22-8867-2be0cdc78e2c" />
