### PR TITLE
url: fix search path

### DIFF
--- a/src/pages/trade/model/use-path.ts
+++ b/src/pages/trade/model/use-path.ts
@@ -21,12 +21,15 @@ export const usePathToMetadata = () => {
   const { data, error, isLoading } = useAssets();
   const { baseSymbol, quoteSymbol } = usePathSymbols();
 
+  const baseSymbolNormalized = baseSymbol.toUpperCase();
+  const quoteSymbolNormalized = quoteSymbol.toUpperCase();
+
   const query = useQuery({
     queryKey: ['pathToMetadata', data, baseSymbol, quoteSymbol],
     queryFn: () => {
       return {
-        baseAsset: data?.find(m => m.symbol === baseSymbol),
-        quoteAsset: data?.find(a => a.symbol === quoteSymbol),
+        baseAsset: data?.find(m => m.symbol === baseSymbolNormalized),
+        quoteAsset: data?.find(a => a.symbol === quoteSymbolNormalized),
       };
     },
   });


### PR DESCRIPTION
references https://github.com/penumbra-zone/dex-explorer/issues/284

Initially, I thought it was related to our custom server‐side middleware matching on `['/', '/trade']`, so any path like `/trade/btc/usdc` wouldn't get intercepted. Turns out simply normalizing the base and quote symbols by capitalizing them fixes the NextJS routing. 

-----------------

https://github.com/user-attachments/assets/e4dee549-cdb7-4b7e-83b9-bc395d77cd34
