### PR TITLE
Correct data extraction from pindexer for explore page

### DIFF
--- a/src/shared/api/server/stats.ts
+++ b/src/shared/api/server/stats.ts
@@ -7,6 +7,7 @@ import { toValueView } from '@/shared/utils/value-view';
 import { Serialized, serialize } from '@/shared/utils/serializer';
 import { getClientSideEnv } from '../env/getClientSideEnv';
 import { DirectedTradingPair } from '@penumbra-zone/protobuf/penumbra/core/component/dex/v1/dex_pb';
+import { getStablecoins } from '@/shared/utils/stables';
 
 export interface StatsData {
   activePairs: number;
@@ -27,7 +28,7 @@ export const getStats = async (): Promise<Serialized<StatsResponse>> => {
     const chainId = getClientSideEnv().PENUMBRA_CHAIN_ID;
     const registryClient = new ChainRegistryClient();
     const registry = await registryClient.remote.get(chainId);
-    const usdcMetadata = registry.getAllAssets().find(x => x.symbol.toLowerCase() === 'usdc');
+    const usdcMetadata = getStablecoins(registry.getAllAssets(), 'usdc').usdc;
     if (!usdcMetadata) {
       return { error: 'USDC not found in registry' };
     }

--- a/src/shared/api/server/stats.ts
+++ b/src/shared/api/server/stats.ts
@@ -6,6 +6,7 @@ import { DurationWindow } from '@/shared/utils/duration';
 import { toValueView } from '@/shared/utils/value-view';
 import { Serialized, serialize } from '@/shared/utils/serializer';
 import { calculateEquivalentInUSDC } from '@/shared/utils/price-conversion';
+import { getClientSideEnv } from '../env/getClientSideEnv';
 
 interface StatsDataBase {
   activePairs: number;
@@ -26,10 +27,7 @@ const STATS_DURATION_WINDOW: DurationWindow = '1d';
 
 export const getStats = async (): Promise<Serialized<StatsResponse>> => {
   try {
-    const chainId = process.env['PENUMBRA_CHAIN_ID'];
-    if (!chainId) {
-      return { error: 'PENUMBRA_CHAIN_ID is not set' };
-    }
+    const chainId = getClientSideEnv().PENUMBRA_CHAIN_ID;
 
     const registryClient = new ChainRegistryClient();
     const registry = await registryClient.remote.get(chainId);

--- a/src/shared/api/server/stats.ts
+++ b/src/shared/api/server/stats.ts
@@ -5,18 +5,15 @@ import { pindexer } from '@/shared/database';
 import { DurationWindow } from '@/shared/utils/duration';
 import { toValueView } from '@/shared/utils/value-view';
 import { Serialized, serialize } from '@/shared/utils/serializer';
-import { calculateEquivalentInUSDC } from '@/shared/utils/price-conversion';
 import { getClientSideEnv } from '../env/getClientSideEnv';
+import { DirectedTradingPair } from '@penumbra-zone/protobuf/penumbra/core/component/dex/v1/dex_pb';
 
-interface StatsDataBase {
+export interface StatsData {
   activePairs: number;
   trades: number;
-  largestPair?: { start: string; end: string };
-  topPriceMover?: { start: string; end: string; percent: number };
-}
-
-export interface StatsData extends StatsDataBase {
-  directVolume: ValueView;
+  largestPair: { pair: DirectedTradingPair; volume: ValueView };
+  topPriceMover: { pair: DirectedTradingPair; percent: number };
+  volume: ValueView;
   liquidity: ValueView;
   largestPairLiquidity?: ValueView;
 }
@@ -28,107 +25,40 @@ const STATS_DURATION_WINDOW: DurationWindow = '1d';
 export const getStats = async (): Promise<Serialized<StatsResponse>> => {
   try {
     const chainId = getClientSideEnv().PENUMBRA_CHAIN_ID;
-
     const registryClient = new ChainRegistryClient();
     const registry = await registryClient.remote.get(chainId);
-
-    // TODO: Add getMetadataBySymbol() helper to registry npm package
-    const allAssets = registry.getAllAssets();
-    const usdcMetadata = allAssets.find(asset => asset.symbol.toLowerCase() === 'usdc');
+    const usdcMetadata = registry.getAllAssets().find(x => x.symbol.toLowerCase() === 'usdc');
     if (!usdcMetadata) {
       return { error: 'USDC not found in registry' };
     }
 
-    const results = await pindexer.stats(
-      STATS_DURATION_WINDOW,
-      // eslint-disable-next-line @typescript-eslint/non-nullable-type-assertion-style -- usdc is defined
-      usdcMetadata.penumbraAssetId as AssetId,
-    );
-
+    const results = await pindexer.stats(STATS_DURATION_WINDOW);
     const stats = results[0];
     if (!stats) {
       return { error: `No stats found` };
     }
-
-    const topPriceMoverStart = allAssets.find(asset => {
-      return asset.penumbraAssetId?.equals(new AssetId({ inner: stats.top_price_mover_start }));
-    });
-    const topPriceMoverEnd = allAssets.find(asset => {
-      return asset.penumbraAssetId?.equals(new AssetId({ inner: stats.top_price_mover_end }));
-    });
-    const topPriceMover = topPriceMoverStart &&
-      topPriceMoverEnd && {
-        start: topPriceMoverStart.symbol,
-        end: topPriceMoverEnd.symbol,
-        percent: stats.top_price_mover_change_percent,
-      };
-
-    const largestPairStart = allAssets.find(asset => {
-      return asset.penumbraAssetId?.equals(
-        new AssetId({ inner: stats.largest_dv_trading_pair_start }),
-      );
-    });
-    const largestPairEnd = allAssets.find(asset => {
-      return asset.penumbraAssetId?.equals(
-        new AssetId({ inner: stats.largest_dv_trading_pair_end }),
-      );
-    });
-    const largestPair = largestPairStart &&
-      largestPairEnd && {
-        start: largestPairStart.symbol,
-        end: largestPairEnd.symbol,
-      };
-
-    let liquidity = toValueView({
-      amount: Math.floor(stats.liquidity),
-      metadata: usdcMetadata,
-    });
-
-    let directVolume = toValueView({
-      amount: Math.floor(stats.direct_volume),
-      metadata: usdcMetadata,
-    });
-
-    let largestPairLiquidity =
-      largestPairEnd &&
-      toValueView({
-        amount: Math.floor(stats.largest_dv_trading_pair_volume),
-        metadata: largestPairEnd,
-      });
-
-    // Converts liquidity and trading volume to their equivalent USDC prices if `usdc_price` is available
-    if (stats.usdc_price && largestPairEnd) {
-      liquidity = calculateEquivalentInUSDC(
-        stats.liquidity,
-        stats.usdc_price,
-        largestPairEnd,
-        usdcMetadata,
-      );
-
-      directVolume = calculateEquivalentInUSDC(
-        stats.direct_volume,
-        stats.usdc_price,
-        largestPairEnd,
-        usdcMetadata,
-      );
-
-      largestPairLiquidity = calculateEquivalentInUSDC(
-        stats.largest_dv_trading_pair_volume,
-        stats.usdc_price,
-        largestPairEnd,
-        usdcMetadata,
-      );
-    }
-
     return serialize({
       activePairs: stats.active_pairs,
       trades: stats.trades,
-      largestPair,
-      topPriceMover,
-      time: new Date(),
-      largestPairLiquidity,
-      liquidity,
-      directVolume,
+      largestPair: {
+        pair: new DirectedTradingPair({
+          start: new AssetId({ inner: stats.largest_dv_trading_pair_start }),
+          end: new AssetId({ inner: stats.largest_dv_trading_pair_end }),
+        }),
+        volume: toValueView({
+          amount: Math.floor(stats.largest_dv_trading_pair_volume),
+          metadata: usdcMetadata,
+        }),
+      },
+      topPriceMover: {
+        pair: new DirectedTradingPair({
+          start: new AssetId({ inner: stats.top_price_mover_start }),
+          end: new AssetId({ inner: stats.top_price_mover_end }),
+        }),
+        percent: stats.top_price_mover_change_percent,
+      },
+      volume: toValueView({ amount: Math.floor(stats.direct_volume), metadata: usdcMetadata }),
+      liquidity: toValueView({ amount: Math.floor(stats.liquidity), metadata: usdcMetadata }),
     });
   } catch (error) {
     return { error: (error as Error).message };

--- a/src/shared/api/server/summary/all.ts
+++ b/src/shared/api/server/summary/all.ts
@@ -34,6 +34,9 @@ export const getAllSummaries = async (
   const allAssets = registry.getAllAssets();
 
   const { stablecoins, usdc } = getStablecoins(allAssets, 'USDC');
+  if (!usdc) {
+    throw new Error('usdc asset does not exist');
+  }
 
   const results = await pindexer.summaries({
     ...params,

--- a/src/shared/api/server/summary/all.ts
+++ b/src/shared/api/server/summary/all.ts
@@ -42,7 +42,7 @@ export const getAllSummaries = async (
     ...params,
     stablecoins: stablecoins.map(asset => asset.penumbraAssetId) as AssetId[],
     // eslint-disable-next-line @typescript-eslint/non-nullable-type-assertion-style -- usdc is defined
-    usdc: usdc?.penumbraAssetId as AssetId,
+    usdc: usdc.penumbraAssetId as AssetId,
   });
 
   const summaries = await Promise.all(

--- a/src/shared/api/server/summary/single.ts
+++ b/src/shared/api/server/summary/single.ts
@@ -37,6 +37,9 @@ export async function GET(req: NextRequest): Promise<NextResponse<Serialized<Sum
   const allAssets = registry.getAllAssets();
 
   const { usdc } = getStablecoins(allAssets, 'USDC');
+  if (!usdc) {
+    return NextResponse.json({ error: 'USDC asset does not exist' }, { status: 500 });
+  }
 
   const baseAssetMetadata = allAssets.find(
     a => a.symbol.toLowerCase() === baseAssetSymbol.toLowerCase(),

--- a/src/shared/api/server/summary/types.ts
+++ b/src/shared/api/server/summary/types.ts
@@ -48,7 +48,7 @@ export const adaptSummary = (
     metadata: quoteAsset,
   });
 
-  let directVolume = toValueView({
+  const directVolume = toValueView({
     amount: Math.floor(summary.direct_volume_indexing_denom_over_window),
     metadata: usdc,
   });

--- a/src/shared/api/server/summary/types.ts
+++ b/src/shared/api/server/summary/types.ts
@@ -39,7 +39,7 @@ export const adaptSummary = (
   summary: DexExPairsSummary,
   baseAsset: Metadata,
   quoteAsset: Metadata,
-  usdc: Metadata | undefined,
+  usdc: Metadata,
   candles?: number[],
   candleTimes?: Date[],
 ): SummaryData => {
@@ -49,20 +49,13 @@ export const adaptSummary = (
   });
 
   let directVolume = toValueView({
-    amount: Math.floor(summary.direct_volume_over_window),
-    metadata: quoteAsset,
+    amount: Math.floor(summary.direct_volume_indexing_denom_over_window),
+    metadata: usdc,
   });
 
   // Converts liquidity and trading volume to their equivalent USDC prices if `usdc_price` is available
-  if (summary.usdc_price && usdc) {
+  if (summary.usdc_price) {
     liquidity = calculateEquivalentInUSDC(summary.liquidity, summary.usdc_price, quoteAsset, usdc);
-
-    directVolume = calculateEquivalentInUSDC(
-      summary.direct_volume_over_window,
-      summary.usdc_price,
-      quoteAsset,
-      usdc,
-    );
   }
 
   const priceDiff = summary.price - summary.price_then;

--- a/src/shared/database/index.ts
+++ b/src/shared/database/index.ts
@@ -67,19 +67,10 @@ class Pindexer {
       .execute();
   }
 
-  async stats(window: DurationWindow, usdc: AssetId): Promise<DexExAggregateSummary[]> {
-    const usdcTable = this.db
-      .selectFrom('dex_ex_pairs_summary')
-      .where('asset_end', '=', Buffer.from(usdc.inner))
-      .where('the_window', '=', '1m')
-      .groupBy(['asset_end', 'asset_start', 'the_window'])
-      .selectAll();
-
+  async stats(window: DurationWindow): Promise<DexExAggregateSummary[]> {
     return this.db
       .selectFrom('dex_ex_aggregate_summary as agg')
       .selectAll()
-      .leftJoin(usdcTable.as('usdc'), 'agg.largest_dv_trading_pair_end', 'usdc.asset_start')
-      .select('usdc.price as usdc_price')
       .where('agg.the_window', '=', window)
       .execute();
   }

--- a/src/shared/utils/serializer.ts
+++ b/src/shared/utils/serializer.ts
@@ -23,7 +23,7 @@ export type Serialized<T> =
       : T;
 
 /** Serializes an object with Protobuf values, turning them into `JsonValue` */
-export const serialize = <VAL,>(value: VAL): Serialized<VAL> => {
+export const serialize = <VAL>(value: VAL): Serialized<VAL> => {
   if (typeof value !== 'object' || value === null) {
     return value as Serialized<VAL>;
   }
@@ -75,7 +75,7 @@ const isSerializedProto = (value: unknown): value is SerializedProto => {
   return !!(value as SerializedProto | undefined)?.proto;
 };
 
-export const deserialize = <VAL,>(value: Serialized<VAL>): VAL => {
+export const deserialize = <VAL>(value: Serialized<VAL>): VAL => {
   if (typeof value !== 'object' || value === null) {
     return value as VAL;
   }

--- a/src/shared/utils/serializer.ts
+++ b/src/shared/utils/serializer.ts
@@ -7,6 +7,7 @@ import {
   Value,
   ValueView,
 } from '@penumbra-zone/protobuf/penumbra/core/asset/v1/asset_pb';
+import { DirectedTradingPair } from '@penumbra-zone/protobuf/penumbra/core/component/dex/v1/dex_pb';
 
 interface SerializedProto {
   proto: string;
@@ -22,7 +23,7 @@ export type Serialized<T> =
       : T;
 
 /** Serializes an object with Protobuf values, turning them into `JsonValue` */
-export const serialize = <VAL>(value: VAL): Serialized<VAL> => {
+export const serialize = <VAL,>(value: VAL): Serialized<VAL> => {
   if (typeof value !== 'object' || value === null) {
     return value as Serialized<VAL>;
   }
@@ -56,6 +57,7 @@ const ProtosByType = {
   'penumbra.core.asset.v1.Metadata': Metadata,
   'penumbra.core.asset.v1.Value': Value,
   'penumbra.core.asset.v1.AssetId': AssetId,
+  'penumbra.core.component.dex.v1.DirectedTradingPair': DirectedTradingPair,
 } as const;
 
 const deserializeProto = (value: SerializedProto): Message<any> => {
@@ -73,7 +75,7 @@ const isSerializedProto = (value: unknown): value is SerializedProto => {
   return !!(value as SerializedProto | undefined)?.proto;
 };
 
-export const deserialize = <VAL>(value: Serialized<VAL>): VAL => {
+export const deserialize = <VAL,>(value: Serialized<VAL>): VAL => {
   if (typeof value !== 'object' || value === null) {
     return value as VAL;
   }


### PR DESCRIPTION
Closes #302.
Closes #300.

The aggregate information wasn't being pulled correctly, I refactored that substantially to simplify the logic.

I touched the summary logic much less, and the only incorrect thing was just not using the recently added pre-calculated USDC volume inside pindexer. Doing so corrects discrepancies between the aggregate view and the per-pair view.

There are still some latent issues stemming from the fact that pindexer assumes directed trading pairs, and this page de-duplicates to get an undirected pair, and so some numbers like volume and liquidity may be only "half" what they should, but that can be corrected later once we display, e.g. volume or liquidity with directions.