### PR TITLE
bug: fix aggregate stats not displaying because of USDC

### DIFF
--- a/src/shared/api/server/stats.ts
+++ b/src/shared/api/server/stats.ts
@@ -28,7 +28,7 @@ export const getStats = async (): Promise<Serialized<StatsResponse>> => {
     const chainId = getClientSideEnv().PENUMBRA_CHAIN_ID;
     const registryClient = new ChainRegistryClient();
     const registry = await registryClient.remote.get(chainId);
-    const usdcMetadata = getStablecoins(registry.getAllAssets(), 'usdc').usdc;
+    const usdcMetadata = getStablecoins(registry.getAllAssets(), 'USDC').usdc;
     if (!usdcMetadata) {
       return { error: 'USDC not found in registry' };
     }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/76ced874-e5e8-4594-93b1-e30d263fd2fc)

Is causes by incorrectly fetching the USDC metadata on the server. This fixes that to allow the explore aggregate stats to work again.