### PR TITLE
Stopgap: treat negative liquidity and volume as positive

### DIFF
--- a/src/shared/api/server/summary/types.ts
+++ b/src/shared/api/server/summary/types.ts
@@ -49,7 +49,7 @@ export const adaptSummary = (
   });
 
   // Converts liquidity and trading volume to their equivalent USDC prices if `usdc_price` is available
-  let rawLiquidity = Math.max(Math.floor(summary.liquidity), 0.0);
+  const rawLiquidity = Math.max(Math.floor(summary.liquidity), 0.0);
   let liquidity: ValueView;
   if (summary.usdc_price) {
     liquidity = calculateEquivalentInUSDC(rawLiquidity, summary.usdc_price, quoteAsset, usdc);

--- a/src/shared/api/server/summary/types.ts
+++ b/src/shared/api/server/summary/types.ts
@@ -43,19 +43,21 @@ export const adaptSummary = (
   candles?: number[],
   candleTimes?: Date[],
 ): SummaryData => {
-  let liquidity = toValueView({
-    amount: Math.floor(summary.liquidity),
-    metadata: quoteAsset,
-  });
-
   const directVolume = toValueView({
-    amount: Math.floor(summary.direct_volume_indexing_denom_over_window),
+    amount: Math.max(Math.floor(summary.direct_volume_indexing_denom_over_window), 0.0),
     metadata: usdc,
   });
 
   // Converts liquidity and trading volume to their equivalent USDC prices if `usdc_price` is available
+  let rawLiquidity = Math.max(Math.floor(summary.liquidity), 0.0);
+  let liquidity: ValueView;
   if (summary.usdc_price) {
-    liquidity = calculateEquivalentInUSDC(summary.liquidity, summary.usdc_price, quoteAsset, usdc);
+    liquidity = calculateEquivalentInUSDC(rawLiquidity, summary.usdc_price, quoteAsset, usdc);
+  } else {
+    liquidity = toValueView({
+      amount: Math.max(Math.floor(rawLiquidity), 0.0),
+      metadata: quoteAsset,
+    });
   }
 
   const priceDiff = summary.price - summary.price_then;

--- a/src/shared/utils/serializer.ts
+++ b/src/shared/utils/serializer.ts
@@ -23,7 +23,7 @@ export type Serialized<T> =
       : T;
 
 /** Serializes an object with Protobuf values, turning them into `JsonValue` */
-export const serialize = <VAL,>(value: VAL): Serialized<VAL> => {
+export const serialize = <VAL>(value: VAL): Serialized<VAL> => {
   if (typeof value !== 'object' || value === null) {
     return value as Serialized<VAL>;
   }
@@ -75,7 +75,7 @@ const isSerializedProto = (value: unknown): value is SerializedProto => {
   return !!(value as SerializedProto | undefined)?.proto;
 };
 
-export const deserialize = <VAL,>(value: Serialized<VAL>): VAL => {
+export const deserialize = <VAL>(value: Serialized<VAL>): VAL => {
   if (typeof value !== 'object' || value === null) {
     return value as VAL;
   }

--- a/src/shared/utils/serializer.ts
+++ b/src/shared/utils/serializer.ts
@@ -23,7 +23,7 @@ export type Serialized<T> =
       : T;
 
 /** Serializes an object with Protobuf values, turning them into `JsonValue` */
-export const serialize = <VAL>(value: VAL): Serialized<VAL> => {
+export const serialize = <VAL,>(value: VAL): Serialized<VAL> => {
   if (typeof value !== 'object' || value === null) {
     return value as Serialized<VAL>;
   }
@@ -75,7 +75,7 @@ const isSerializedProto = (value: unknown): value is SerializedProto => {
   return !!(value as SerializedProto | undefined)?.proto;
 };
 
-export const deserialize = <VAL>(value: Serialized<VAL>): VAL => {
+export const deserialize = <VAL,>(value: Serialized<VAL>): VAL => {
   if (typeof value !== 'object' || value === null) {
     return value as VAL;
   }


### PR DESCRIPTION
This is a data issue in pindexer, but we should handle this in a robust way, instead of keeling over.

Closes #324.