### PR TITLE
sorting by decreasing volume

### DIFF
--- a/src/shared/api/server/summary/all.ts
+++ b/src/shared/api/server/summary/all.ts
@@ -74,17 +74,17 @@ export const getAllSummaries = async (
     }),
   );
 
-  // Sorting by decreasing liquidity in the pool
+  // Sorting by decreasing 24 hour volume in the pool
   // TODO: sort directly in SQL to avoid breaking server-side pagination
   const sortedSummaries = summaries.filter(Boolean).sort((a, b) => {
     if (!a || !b) {
       return 0;
     }
 
-    const aLiquidity = Number(getFormattedAmtFromValueView(a.liquidity)) || 0;
-    const bLiquidity = Number(getFormattedAmtFromValueView(b.liquidity)) || 0;
+    const aVolume = Number(getFormattedAmtFromValueView(a.directVolume)) || 0;
+    const bVolume = Number(getFormattedAmtFromValueView(b.directVolume)) || 0;
 
-    return bLiquidity - aLiquidity;
+    return bVolume - aVolume;
   });
 
   return sortedSummaries.map(data => serialize(data)) as Serialized<SummaryData>[];


### PR DESCRIPTION
follow up from https://github.com/penumbra-zone/dex-explorer/pull/254, we should instead sort pairs by direct volume rather than liquidity on the explore page

-----------

_before_

<img width="1728" alt="Screenshot 2025-02-05 at 11 08 10 AM" src="https://github.com/user-attachments/assets/f456d400-d685-4e57-afc9-cbe9a05635e1" />

------------

_after_

<img width="1728" alt="Screenshot 2025-02-05 at 11 08 41 AM" src="https://github.com/user-attachments/assets/0e25313b-5064-446f-b5f2-a67b56afb248" />

