### PR TITLE
explore: disable top price mover until query is fixed

### DIFF
--- a/src/pages/explore/ui/stats.tsx
+++ b/src/pages/explore/ui/stats.tsx
@@ -96,9 +96,9 @@ export const ExploreStats = () => {
         )}
       </InfoCard>
       <InfoCard title='Top Price Mover (24h)' loading={isLoading}>
-          <Text large color='text.primary'>
-            -
-          </Text>
+        <Text large color='text.primary'>
+          -
+        </Text>
       </InfoCard>
     </div>
   );

--- a/src/pages/explore/ui/stats.tsx
+++ b/src/pages/explore/ui/stats.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { round } from '@penumbra-zone/types/round';
+// import { round } from '@penumbra-zone/types/round';
 import { Text } from '@penumbra-zone/ui/Text';
 import { InfoCard } from './info-card';
 import { pluralizeAndShortify } from '@/shared/utils/pluralize';
@@ -96,19 +96,9 @@ export const ExploreStats = () => {
         )}
       </InfoCard>
       <InfoCard title='Top Price Mover (24h)' loading={isLoading}>
-        {registry && stats?.topPriceMover ? (
-          <>
-            <DirectedTradingPairText registry={registry} pair={stats.topPriceMover.pair} />
-            <Text large color={stats.topPriceMover.percent ? 'success.light' : 'destructive.light'}>
-              {stats.topPriceMover.percent && '+'}
-              {round({ value: stats.topPriceMover.percent, decimals: 1 })}%
-            </Text>
-          </>
-        ) : (
           <Text large color='text.primary'>
             -
           </Text>
-        )}
       </InfoCard>
     </div>
   );


### PR DESCRIPTION
A nonsensical value on the top of the first page that a user sees casts doubt on the entire render, so we are going to disable it until we fix it.

Before:

<img width="1108" alt="Screenshot 2025-02-13 at 8 55 18 AM" src="https://github.com/user-attachments/assets/9e89fa37-d23f-465f-889b-c5299063bff1" />

After:
<img width="1117" alt="Screenshot 2025-02-13 at 8 56 26 AM" src="https://github.com/user-attachments/assets/0dba1e05-62da-471b-b139-ebc083fef6f9" />
