### PR TITLE
ci: more verbose request logging

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -17,6 +17,7 @@
             jq
             just
             pnpm
+            nodejs_22
             postgresql
 
             # for deployment/ci

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -91,6 +91,19 @@ const nextConfig = {
   typescript: {
     ignoreBuildErrors: true,
   },
+  logging: {
+    fetches: {
+      // Display URLs for external targets of fetch requests
+      fullUrl: true,
+      // Also display URLs even when a cache is hit for the hot-module-reloading in dev.
+      hmrRefreshes: true,
+    },
+  },
+  // Disabling HMR in local dev requires NextJS >= v15.x, so disabling for now.
+  // experimental: {
+  //   // Don't cache the HMR in local dev.
+  //   serverComponentsHmrCache: false,
+  // },
 };
 
 export default nextConfig;


### PR DESCRIPTION
When fetching external URLs, notably the Registry JSON, we want to see in the logs whether that's a cache hit or miss. Tweaking the logging config to allow just that.

Also includes some references to config options that we can only enable once we upgrade to NextJS v15. See relevant docs here: https://nextjs.org/docs/app/api-reference/config/next-config-js/logging

These changes were made while investigating #373. Given that it pertains to logging, also relevant to #352.