### PR TITLE
bug: calculate route book correctly

### DIFF
--- a/src/shared/api/server/book/index.ts
+++ b/src/shared/api/server/book/index.ts
@@ -90,15 +90,15 @@ export async function GET(req: NextRequest): Promise<NextResponse<RouteBookApiRe
   const buyMulti = processSimulation({ res: buyRes, registry, limit, quote_to_base: false });
   const sellMulti = processSimulation({ res: sellRes, registry, limit, quote_to_base: true });
 
-  return NextResponse.json(
-    serializeResponse({
-      singleHops: {
-        buy: buyMulti.filter(t => t.hops.length === 2),
-        sell: sellMulti.filter(t => t.hops.length === 2),
-      },
-      multiHops: { buy: buyMulti, sell: sellMulti },
-    }),
-  );
+  const response = {
+    singleHops: {
+      buy: buyMulti.filter(t => t.hops.length === 2),
+      sell: sellMulti.filter(t => t.hops.length === 2),
+    },
+    multiHops: { buy: buyMulti, sell: sellMulti },
+  };
+  console.log(JSON.stringify(response));
+  return NextResponse.json(serializeResponse(response));
 }
 
 const simulateTrade = async (

--- a/src/shared/utils/value-view.ts
+++ b/src/shared/utils/value-view.ts
@@ -1,6 +1,8 @@
+import { Registry } from '@penumbra-labs/registry';
 import {
   AssetId,
   Metadata,
+  Value,
   ValueView,
 } from '@penumbra-zone/protobuf/penumbra/core/asset/v1/asset_pb';
 import { splitLoHi } from '@penumbra-zone/types/lo-hi';
@@ -33,4 +35,17 @@ export const toValueView = (props: ToValueViewProps) => {
       },
     });
   }
+};
+
+/**
+ * Use a registry to convert a {@link Value} into a {@link ValueView}.
+ */
+export const registryView = (registry: Registry, value: Value): ValueView => {
+  const metadata = value.assetId && registry.tryGetMetadata(value.assetId);
+  if (!metadata) {
+    return new ValueView({ valueView: { case: 'unknownAssetId', value } });
+  }
+  return new ValueView({
+    valueView: { case: 'knownAssetId', value: { amount: value.amount, metadata } },
+  });
 };


### PR DESCRIPTION
Closes #369.

# Digression

However! Where there's smoke there's fire, and I think there's probably other places where we're doing the math wrong, given the tangle nest interactions of pnum, BigNumber, etc. Longer term we should probably have some kind of actual domain type for prices, with functions for the associated ability to apply prices to values, with a runtime check that the asset ids match, and defer rendering as late as possible, with a single source of truth for doing the correct tricky math around exponents when rendering a price.

# The Problem

Previously, the route book would return odd data, like infinities, or negative spreads:
![image](https://github.com/user-attachments/assets/ab6913a1-6107-4cf0-bb9a-cbab884d9d52)


I think the culprit here boils down to this part of the processing logic:
https://github.com/penumbra-zone/dex-explorer/blob/18fac1d01300c3a571f4aaea610cf013bc6fd2e5/src/shared/api/server/book/helpers.ts#L63-L74
which erroneously figures out the price by first converting the input and output amounts to formatted strings, which only have 6 significant decimals (bad news when—e.g.—Bitcoin is 100k or so, and this starts to truncate information)

# The Solution

Avoid using formatting logic to do price calculation. I also added a utility function for converting a `Value` into a `ValueView` given a registry, which seems to be usually what we want when we do random registry lookups, this could be used more pervasively to simplify code subsequently.

The fix is just to convert to BigNumber using pnum on a ValueView, which correctly handles exponents (side note: we should audit that function again, I think in particular the codepath of providing a number then an exponent separately might be wrong?), and allows dividing the output amount by the input amount.

# Result

![image](https://github.com/user-attachments/assets/688813eb-d175-486d-afba-21260b9e6850)

We now get a route book that's sensible for BTC again
