### PR TITLE
fix: #394: transaction pagination history

### DIFF
--- a/src/entities/position/ui/error-notice.tsx
+++ b/src/entities/position/ui/error-notice.tsx
@@ -2,7 +2,7 @@ import { BlockchainError } from '@/shared/ui/blockchain-error';
 
 export const ErrorNotice = () => {
   return (
-    <div className='min-h-screen flex items-center justify-center'>
+    <div className='min-h-[250px] flex items-center justify-center'>
       <BlockchainError
         message='An error occurred while loading data from the blockchain'
         direction='column'

--- a/src/entities/position/ui/table.tsx
+++ b/src/entities/position/ui/table.tsx
@@ -127,7 +127,10 @@ export const PositionsTable = observer(({ base, quote, stateFilter }: PositionsT
   }
 
   return (
-    <div className='grid grid-cols-[80px_1fr_1fr_80px_1fr_1fr_1fr_1fr] overflow-y-auto overflow-x-auto'>
+    <div
+      className='grid grid-cols-[80px_1fr_1fr_80px_1fr_1fr_1fr_1fr] overflow-y-auto overflow-x-auto'
+      style={{ overflowAnchor: 'none' }}
+    >
       <Density slim>
         <div className='grid grid-cols-subgrid col-span-8'>
           <SortableTableHeader sortKey='type'>Type</SortableTableHeader>

--- a/src/pages/portfolio/api/use-transactions.ts
+++ b/src/pages/portfolio/api/use-transactions.ts
@@ -17,14 +17,8 @@ export const useTransactions = (subaccount = 0) => {
     queryFn: async ({ pageParam }) => {
       const res = await Array.fromAsync(penumbra.service(ViewService).transactionInfo({}));
 
-      // TODO: implement sorting by height in the ViewService, and use `limitAsync` here after it
-      res.sort((a, b) => Number((b.txInfo?.height ?? 0n) - (a.txInfo?.height ?? 0n)));
-
-      const offset = BASE_LIMIT * (pageParam as number);
-      const txs = res.slice(offset, offset + BASE_LIMIT);
-
       // Filters and maps the array at the same time
-      return txs.reduce<TransactionInfo[]>((accum, tx) => {
+      const reduced = res.reduce<TransactionInfo[]>((accum, tx) => {
         const addresses = tx.txInfo?.perspective?.addressViews;
 
         if (
@@ -46,6 +40,12 @@ export const useTransactions = (subaccount = 0) => {
         accum.push(tx.txInfo);
         return accum;
       }, []);
+
+      // TODO: implement sorting by height in the ViewService, and use `limitAsync` here after it
+      reduced.sort((a, b) => Number(a.height - b.height));
+
+      const offset = BASE_LIMIT * (pageParam as number);
+      return reduced.slice(offset, offset + BASE_LIMIT);
     },
   });
 };

--- a/src/pages/portfolio/ui/position-tabs.tsx
+++ b/src/pages/portfolio/ui/position-tabs.tsx
@@ -33,13 +33,11 @@ export const PortfolioPositionTabs = () => {
           </Density>
         </div>
 
-        <div className='max-h-[500px] overflow-y-auto' style={{ overflowAnchor: 'none' }}>
-          {tab === PortfolioTab.OpenPositions && <PortfolioOpenPositions />}
+        {tab === PortfolioTab.OpenPositions && <PortfolioOpenPositions />}
 
-          {tab === PortfolioTab.ClosedPositions && <PortfolioClosedPositions />}
+        {tab === PortfolioTab.ClosedPositions && <PortfolioClosedPositions />}
 
-          {tab === PortfolioTab.History && <PortfolioTransactions />}
-        </div>
+        {tab === PortfolioTab.History && <PortfolioTransactions />}
       </div>
     </Card>
   );

--- a/src/pages/portfolio/ui/position-tabs.tsx
+++ b/src/pages/portfolio/ui/position-tabs.tsx
@@ -33,11 +33,13 @@ export const PortfolioPositionTabs = () => {
           </Density>
         </div>
 
-        {tab === PortfolioTab.OpenPositions && <PortfolioOpenPositions />}
+        <div className='max-h-[500px] overflow-y-auto' style={{ overflowAnchor: 'none' }}>
+          {tab === PortfolioTab.OpenPositions && <PortfolioOpenPositions />}
 
-        {tab === PortfolioTab.ClosedPositions && <PortfolioClosedPositions />}
+          {tab === PortfolioTab.ClosedPositions && <PortfolioClosedPositions />}
 
-        {tab === PortfolioTab.History && <PortfolioTransactions />}
+          {tab === PortfolioTab.History && <PortfolioTransactions />}
+        </div>
       </div>
     </Card>
   );

--- a/src/pages/portfolio/ui/transactions.tsx
+++ b/src/pages/portfolio/ui/transactions.tsx
@@ -13,7 +13,6 @@ import { connectionStore } from '@/shared/model/connection';
 import { useGetMetadataByAssetId } from '@/shared/api/assets';
 import { BlockchainError } from '@/shared/ui/blockchain-error';
 import { useObserver } from '@/shared/utils/use-observer';
-import SpinnerIcon from '@/shared/assets/spinner-icon.svg';
 import { useTransactions } from '../api/use-transactions';
 import { NoData } from './no-data';
 
@@ -42,11 +41,15 @@ export const PortfolioTransactions = observer(() => {
     isRefetching,
     isFetchingNextPage,
     fetchNextPage,
+    hasNextPage,
   } = useTransactions(subaccount);
 
-  const { observerEl } = useObserver(isLoading || isRefetching || isFetchingNextPage, () => {
-    void fetchNextPage();
-  });
+  const { observerEl } = useObserver(
+    isLoading || isRefetching || isFetchingNextPage || !hasNextPage,
+    () => {
+      void fetchNextPage();
+    },
+  );
 
   const getTxId = (tx: TransactionInfo): string => {
     return tx.id?.inner ? uint8ArrayToHex(tx.id.inner) : '';
@@ -88,12 +91,6 @@ export const PortfolioTransactions = observer(() => {
             }
           />
         )),
-      )}
-
-      {isFetchingNextPage && (
-        <div className='flex items-center justify-center h-6 my-1'>
-          <SpinnerIcon className='animate-spin' />
-        </div>
       )}
 
       {/* An element that triggers the infinite scroll when visible */}

--- a/src/pages/portfolio/ui/transactions.tsx
+++ b/src/pages/portfolio/ui/transactions.tsx
@@ -56,7 +56,7 @@ export const PortfolioTransactions = observer(() => {
   };
 
   return (
-    <div className='flex flex-col gap-1'>
+    <div className='flex flex-col gap-1' style={{ overflowAnchor: 'none' }}>
       {isLoading &&
         Array.from({ length: 3 }).map((_, index) => (
           <div key={index} className='h-[72px]'>

--- a/src/shared/utils/use-observer.ts
+++ b/src/shared/utils/use-observer.ts
@@ -1,35 +1,35 @@
 import { useEffect, useRef } from 'react';
+import { useThrottle } from '@/shared/utils/use-throttle';
 
 /** A hook that fires the callback when observed element (on the bottom of the page) is in the view */
 export const useObserver = (disabled: boolean, cb: VoidFunction) => {
   const observerEl = useRef<HTMLDivElement | null>(null);
+  const throttledFunction = useThrottle(cb, 400);
 
   useEffect(() => {
     const ref = observerEl.current;
-    const observer = new IntersectionObserver(
-      entries => {
-        const [entry] = entries;
-        if (entry?.isIntersecting && !disabled) {
-          cb();
-        }
-      },
-      {
-        root: null,
-        rootMargin: '20px',
-        threshold: 1.0,
-      },
-    );
-
     if (ref) {
+      const observer = new IntersectionObserver(
+        entries => {
+          const [entry] = entries;
+          if (entry?.isIntersecting && !disabled) {
+            throttledFunction();
+          }
+        },
+        {
+          root: null,
+          rootMargin: '20px',
+          threshold: 1.0,
+        },
+      );
       observer.observe(ref);
-    }
 
-    return () => {
-      if (ref) {
+      return () => {
         observer.unobserve(ref);
-      }
-    };
-  }, [cb, disabled]);
+      };
+    }
+    return () => {};
+  }, [disabled, throttledFunction]);
 
   return {
     observerEl,

--- a/src/shared/utils/use-throttle.ts
+++ b/src/shared/utils/use-throttle.ts
@@ -1,0 +1,22 @@
+import { useCallback, useRef } from 'react';
+
+/**
+ * Creates a function that fires only once in a given time frame.
+ *
+ * This hook adapts the function for React since the framework tends
+ * to reset function's inner state on each re-render.
+ */
+export function useThrottle<T extends (...args: unknown[]) => void>(func: T, limit: number) {
+  const lastCall = useRef(0);
+
+  return useCallback(
+    (...args: Parameters<T>) => {
+      const now = Date.now();
+      if (now - lastCall.current >= limit) {
+        lastCall.current = now;
+        func(...args);
+      }
+    },
+    [func, limit],
+  );
+}


### PR DESCRIPTION
Closes #394 

Thanks to @TalDerei, the #394 issue made me reflect on the infinite scroll and generalize the `useObserver` hook.

PR contents:
- Fix to `useTransactions` hook – it was incorrectly limiting data before subaccount filtering
- Improve `useObserver` hook – it now uses throttled data fetcher, meaning that next page requests cannot fire more often than 400ms
- Remove the loader from transactions list – the request time is so fast that showing the loader only caused the fiickering